### PR TITLE
Refactoring Lab API

### DIFF
--- a/PittAPI/__init__.py
+++ b/PittAPI/__init__.py
@@ -16,3 +16,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 '''
+import requests
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)

--- a/PittAPI/course.py
+++ b/PittAPI/course.py
@@ -20,9 +20,6 @@ import warnings
 
 import requests
 from bs4 import BeautifulSoup, SoupStrainer
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
-
-requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 URL = 'http://www.courses.as.pitt.edu/'
 
@@ -119,4 +116,6 @@ def get_class_description(term, class_number):
     if 'no courses by' in page.text or 'Search by subject' in page.text:
         raise ValueError('Invalid class number.')
     soup = BeautifulSoup(page.text, 'lxml', parse_only=SoupStrainer(['td']))
-    return soup.findAll('td', {'colspan': '9'})[1].text
+    return {
+        'description': soup.findAll('td', {'colspan': '9'})[1].text
+    }

--- a/PittAPI/dining.py
+++ b/PittAPI/dining.py
@@ -19,10 +19,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 import requests
 import grequests
-from bs4 import BeautifulSoup, SoupStrainer
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
-
-requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 sess = requests.session()
 

--- a/PittAPI/lab.py
+++ b/PittAPI/lab.py
@@ -46,6 +46,7 @@ def get_status(lab_name):
 
 
 def _extract_machines(data):
+    """Gets available computer totals for each OS into a list."""
     machines = []
     for machine in data.split(','):
         machine = machine.strip()
@@ -54,6 +55,7 @@ def _extract_machines(data):
 
 
 def _make_status(state, win=0, mac=0, linux=0):
+    """Creates proper dictionary response for getting lab status."""
     return {
         'status': state,
         'windows': win,
@@ -63,7 +65,7 @@ def _make_status(state, win=0, mac=0, linux=0):
 
 
 def _validate_lab(lab):
-    '''Corrects case of lab name and checks whether it's valid.'''
+    """Corrects case of lab name and checks whether it's valid."""
     lab = lab.upper()
     if lab in LOCATIONS:
         return lab

--- a/PittAPI/lab.py
+++ b/PittAPI/lab.py
@@ -18,54 +18,50 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 '''
 
 import requests
-from bs4 import BeautifulSoup, SoupStrainer
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
-
-requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+from bs4 import BeautifulSoup
 
 session = requests.session()
 
-location_dict = {
-    'ALUMNI': 0,
-    'BENEDUM': 1,
-    'CATH_G26': 2,
-    'CATH_G27': 3,
-    'LAWRENCE': 4,
-    'HILLMAN': 5,
-    'SUTH': 6
-}
+LOCATIONS = ['ALUMNI', 'BENEDUM', 'CATH_G27', 'CATH_G62', 'LAWRENCE', 'HILLMAN', 'SUTH']
+URL = 'http://labinformation.cssd.pitt.edu/'
 
 
 def get_status(lab_name):
-    '''
-    :returns: a dictionary with status and amount of OS machines.
+    """Returns a dictionary with status and amount of OS machines."""
+    lab_name = _validate_lab(lab_name)
 
-    :param: lab_name: Lab name
-    '''
-
-    lab_name = lab_name.upper()
-    url = 'http://labinformation.cssd.pitt.edu/'
-    page = session.get(url)
+    page = session.get(URL)
     soup = BeautifulSoup(page.text, 'lxml')
     labs = soup.span.text.strip().split('  ')
+    status, *machines = labs[LOCATIONS.index(lab_name)].split(':')
 
-    lab = labs[location_dict[lab_name]].split(':')
-    status_dict = {}
-    if len(lab) > 1:
-        lab = [x.strip() for x in lab[1].split(',')]
-        machines = [int(x[:x.index(' ')]) for x in lab]
-        status_dict = {
-            u'status': u'open',
-            u'windows': machines[0],
-            u'mac': machines[1],
-            u'linux': machines[2]
-        }
+    if 'open' in status:
+        return _make_status('open', *_extract_machines(machines))
     else:
-        status_dict = {
-            u'status': u'closed',
-            u'windows': 0,
-            u'mac': 0,
-            u'linux': 0
-        }
+        return _make_status('closed')
 
-    return status_dict
+
+def _extract_machines(data):
+    machines = []
+    for machine in data.split(','):
+        machine = machine.strip()
+        machines.append(int(machine[:machine.index(' ')]))
+    return machines
+
+
+def _make_status(state, win=0, mac=0, linux=0):
+    return {
+        'status': state,
+        'windows': win,
+        'mac': mac,
+        'linux': linux
+    }
+
+
+def _validate_lab(lab):
+    '''Corrects case of lab name and checks whether it's valid.'''
+    lab = lab.upper()
+    if lab in LOCATIONS:
+        return lab
+    else:
+        raise ValueError("Invalid lab name")

--- a/PittAPI/lab.py
+++ b/PittAPI/lab.py
@@ -28,21 +28,24 @@ URL = 'http://labinformation.cssd.pitt.edu/'
 
 def get_status(lab_name):
     """Returns a dictionary with status and amount of OS machines."""
-    lab_name = _validate_lab(lab_name)
-
-    text = ""
-    while not text:
-        page = session.get(URL)
-        soup = BeautifulSoup(page.text, 'lxml')
-        text = soup.span.text
-
-    labs = text.strip().split('  ')
+    lab_name, labs = _validate_lab(lab_name), _fetch_labs()
     status, *machines = labs[LOCATIONS.index(lab_name)].split(':')
 
     if 'open' in status:
         return _make_status('open', *_extract_machines(machines[0]))
     else:
         return _make_status('closed')
+
+
+def _fetch_labs():
+    """Fetches text of status/machines of all labs."""
+    text = ''
+    while not text:
+        page = session.get(URL)
+        soup = BeautifulSoup(page.text, 'lxml')
+        text = soup.span.text
+
+    return text.strip().split('  ')
 
 
 def _extract_machines(data):

--- a/PittAPI/lab.py
+++ b/PittAPI/lab.py
@@ -30,13 +30,17 @@ def get_status(lab_name):
     """Returns a dictionary with status and amount of OS machines."""
     lab_name = _validate_lab(lab_name)
 
-    page = session.get(URL)
-    soup = BeautifulSoup(page.text, 'lxml')
-    labs = soup.span.text.strip().split('  ')
+    text = ""
+    while not text:
+        page = session.get(URL)
+        soup = BeautifulSoup(page.text, 'lxml')
+        text = soup.span.text
+
+    labs = text.strip().split('  ')
     status, *machines = labs[LOCATIONS.index(lab_name)].split(':')
 
     if 'open' in status:
-        return _make_status('open', *_extract_machines(machines))
+        return _make_status('open', *_extract_machines(machines[0]))
     else:
         return _make_status('closed')
 

--- a/PittAPI/laundry.py
+++ b/PittAPI/laundry.py
@@ -21,9 +21,6 @@ import re
 
 import requests
 from bs4 import BeautifulSoup
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
-
-requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 session = requests.session()
 

--- a/PittAPI/news.py
+++ b/PittAPI/news.py
@@ -22,10 +22,6 @@ import math
 import requests
 import grequests
 
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
-
-requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
-
 sess = requests.session()
 
 

--- a/PittAPI/people.py
+++ b/PittAPI/people.py
@@ -18,11 +18,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 '''
 
 import math
-import requests
-import grequests
 import urllib.parse
 
-requests.packages.urllib3.disable_warnings()
+import grequests
 
 
 def _get_person_url(query, max_people):

--- a/PittAPI/shuttle.py
+++ b/PittAPI/shuttle.py
@@ -18,9 +18,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 '''
 
 import requests
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
-
-requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 sess = requests.session()
 

--- a/docs/LAB-API.md
+++ b/docs/LAB-API.md
@@ -6,8 +6,8 @@
 ### **Location Codes:**
   - Alumni Hall: `"ALUMNI"`
   - Benedum Hall: `"BENEDUM"`
-  - Cathedral G26: `"CATH_G27"`
-  - Cathedral G27: `"CATH_G62"`
+  - Cathedral G27: `"CATH_G27"`
+  - Cathedral G62: `"CATH_G62"`
   - David Lawrence Hall: `"LAWRENCE"`
   - Hillman Library: `"HILLMAN"`
   - Sutherland Hall: `"SUTH"`

--- a/docs/LAB-API.md
+++ b/docs/LAB-API.md
@@ -17,7 +17,7 @@
 ### **get_status(lab_name)**
 
 #### **Parameters**:
-  - `lab_name`: Lab name (comes from LabAPI's **LOCATION**)
+  - `lab_name`: Lab name (comes from LabAPI's **LOCATIONS**)
 
 #### **Returns**:
 Returns a dictionary with status and amount of OS machines.

--- a/docs/LAB-API.md
+++ b/docs/LAB-API.md
@@ -3,11 +3,11 @@
 
 # Lab API
 
-### **location_dict**
+### **Location Codes:**
   - Alumni Hall: `"ALUMNI"`
   - Benedum Hall: `"BENEDUM"`
-  - Cathedral G26: `"CATH_G26"`
-  - Cathedral G27: `"CATH_G27"`
+  - Cathedral G26: `"CATH_G27"`
+  - Cathedral G27: `"CATH_G62"`
   - David Lawrence Hall: `"LAWRENCE"`
   - Hillman Library: `"HILLMAN"`
   - Sutherland Hall: `"SUTH"`
@@ -17,7 +17,21 @@
 ### **get_status(lab_name)**
 
 #### **Parameters**:
-  - `lab_name`: Lab name (comes from LabAPI's **location_dict**)
+  - `lab_name`: Lab name (comes from LabAPI's **LOCATION**)
 
 #### **Returns**:
 Returns a dictionary with status and amount of OS machines.
+
+#### **Example**:
+
+###### **Code**:
+```python
+get_status(lab_name='ALUMNI')
+get_status(lab_name='CATH_G62')
+```
+
+###### **Sample Output**:
+```python
+{'status': 'closed', 'windows': 0, 'mac': 0, 'linux': 0}
+{'status': 'open', 'windows': 96, 'mac': 29, 'linux': 2}
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,3 +5,5 @@
 - [Laundry API](LAUNDRY-API.md)
 - [People API](PEOPLE-API.md)
 - [Dining API](DINING-API.md)
+- [Shuttle API](SHUTTLE-API.md)
+- [News API](NEWS-API.md)

--- a/tests/course_test.py
+++ b/tests/course_test.py
@@ -54,7 +54,7 @@ class CourseTest(unittest.TestCase):
 
     @timeout_decorator.timeout(DEFAULT_TIMEOUT, timeout_exception=PittServerError)
     def test_get_class_description(self):
-        self.assertIsInstance(course.get_class_description(TERM, '10045'), str)
+        self.assertIsInstance(course.get_class_description(TERM, '10045'), dict)
 
     @timeout_decorator.timeout(DEFAULT_TIMEOUT, timeout_exception=PittServerError)
     def test_invalid_class_number(self):

--- a/tests/lab_test.py
+++ b/tests/lab_test.py
@@ -34,8 +34,25 @@ class LabTest(unittest.TestCase):
     def test_get_status_sutherland(self):
         self.assertIsInstance(lab.get_status("SUTH"), dict)
 
-    def test_lab_validation(self):
+    def test_lab_name_validation(self):
         valid, fake = lab.LOCATIONS[0].lower(), 'test'
         self.assertTrue(lab._validate_lab(valid), lab.LOCATIONS[0])
         self.assertRaises(ValueError, lab._validate_lab, fake)
+
+    def test_make_status(self):
+        keys = ['status', 'windows', 'mac', 'linux']
+        closed = lab._make_status('closed')
+        open = lab._make_status('open', 1, 1, 1)
+
+        self.assertIsInstance(closed, dict)
+        self.assertIsInstance(open, dict)
+
+        self.assertTrue(closed[keys[0]], 'closed')
+        self.assertTrue(open[keys[0]], 'open')
+
+        for key in keys[1:]:
+            self.assertTrue(closed[key], 0)
+            self.assertTrue(open[key], 1)
+
+
 

--- a/tests/lab_test.py
+++ b/tests/lab_test.py
@@ -47,12 +47,15 @@ class LabTest(unittest.TestCase):
         self.assertIsInstance(closed, dict)
         self.assertIsInstance(open, dict)
 
-        self.assertTrue(closed[keys[0]], 'closed')
-        self.assertTrue(open[keys[0]], 'open')
+        self.assertEqual(closed[keys[0]], 'closed')
+        self.assertEqual(open[keys[0]], 'open')
 
         for key in keys[1:]:
-            self.assertTrue(closed[key], 0)
-            self.assertTrue(open[key], 1)
+            self.assertEqual(closed[key], 0)
+            self.assertEqual(open[key], 1)
 
-
-
+    def test_extract_machines(self):
+        data = '123 hello_world, 456 macOS, 789 cool, 3 nice'
+        info = lab._extract_machines(data)
+        self.assertIsInstance(info, list)
+        self.assertEqual(info, [123, 456, 789, 3])

--- a/tests/lab_test.py
+++ b/tests/lab_test.py
@@ -2,34 +2,40 @@ import unittest
 import timeout_decorator
 
 from PittAPI import lab
-from . import PittServerError
+from . import PittServerError, DEFAULT_TIMEOUT
 
 
 class LabTest(unittest.TestCase):
-    @timeout_decorator.timeout(30, timeout_exception=PittServerError)
-    def test_lab_get_status_alumni(self):
+    @timeout_decorator.timeout(DEFAULT_TIMEOUT, timeout_exception=PittServerError)
+    def test_get_status_alumni(self):
         self.assertIsInstance(lab.get_status("ALUMNI"), dict)
 
-    @timeout_decorator.timeout(30, timeout_exception=PittServerError)
-    def test_lab_get_status_benedum(self):
+    @timeout_decorator.timeout(DEFAULT_TIMEOUT, timeout_exception=PittServerError)
+    def test_get_status_benedum(self):
         self.assertIsInstance(lab.get_status("BENEDUM"), dict)
 
-    @timeout_decorator.timeout(30, timeout_exception=PittServerError)
-    def test_lab_get_status_cathg26(self):
-        self.assertIsInstance(lab.get_status("CATH_G26"), dict)
-
-    @timeout_decorator.timeout(30, timeout_exception=PittServerError)
-    def test_lab_get_status_cathg27(self):
+    @timeout_decorator.timeout(DEFAULT_TIMEOUT, timeout_exception=PittServerError)
+    def test_get_status_cathg27(self):
         self.assertIsInstance(lab.get_status("CATH_G27"), dict)
 
-    @timeout_decorator.timeout(30, timeout_exception=PittServerError)
-    def test_lab_get_status_lawrence(self):
+    @timeout_decorator.timeout(DEFAULT_TIMEOUT, timeout_exception=PittServerError)
+    def test_get_status_cathg62(self):
+        self.assertIsInstance(lab.get_status("CATH_G62"), dict)
+
+    @timeout_decorator.timeout(DEFAULT_TIMEOUT, timeout_exception=PittServerError)
+    def test_get_status_lawrence(self):
         self.assertIsInstance(lab.get_status("LAWRENCE"), dict)
 
-    @timeout_decorator.timeout(30, timeout_exception=PittServerError)
-    def test_lab_get_status_hillman(self):
+    @timeout_decorator.timeout(DEFAULT_TIMEOUT, timeout_exception=PittServerError)
+    def test_get_status_hillman(self):
         self.assertIsInstance(lab.get_status("HILLMAN"), dict)
 
-    @timeout_decorator.timeout(30, timeout_exception=PittServerError)
-    def test_lab_get_status_sutherland(self):
+    @timeout_decorator.timeout(DEFAULT_TIMEOUT, timeout_exception=PittServerError)
+    def test_get_status_sutherland(self):
         self.assertIsInstance(lab.get_status("SUTH"), dict)
+
+    def test_lab_validation(self):
+        valid, fake = lab.LOCATIONS[0].lower(), 'test'
+        self.assertTrue(lab._validate_lab(valid), lab.LOCATIONS[0])
+        self.assertRaises(ValueError, lab._validate_lab, fake)
+

--- a/tests/lab_test.py
+++ b/tests/lab_test.py
@@ -1,42 +1,35 @@
-import pprint
 import unittest
 import timeout_decorator
 
 from PittAPI import lab
-
-
-pp = pprint.PrettyPrinter(indent=2)
-
-
-class PittServerDownException(Exception):
-    """Raise when a Pitt server is down or timing out"""
+from . import PittServerError
 
 
 class LabTest(unittest.TestCase):
-    @timeout_decorator.timeout(30, timeout_exception=PittServerDownException)
+    @timeout_decorator.timeout(30, timeout_exception=PittServerError)
     def test_lab_get_status_alumni(self):
         self.assertIsInstance(lab.get_status("ALUMNI"), dict)
 
-    @timeout_decorator.timeout(30, timeout_exception=PittServerDownException)
+    @timeout_decorator.timeout(30, timeout_exception=PittServerError)
     def test_lab_get_status_benedum(self):
         self.assertIsInstance(lab.get_status("BENEDUM"), dict)
 
-    @timeout_decorator.timeout(30, timeout_exception=PittServerDownException)
+    @timeout_decorator.timeout(30, timeout_exception=PittServerError)
     def test_lab_get_status_cathg26(self):
         self.assertIsInstance(lab.get_status("CATH_G26"), dict)
 
-    @timeout_decorator.timeout(30, timeout_exception=PittServerDownException)
+    @timeout_decorator.timeout(30, timeout_exception=PittServerError)
     def test_lab_get_status_cathg27(self):
         self.assertIsInstance(lab.get_status("CATH_G27"), dict)
 
-    @timeout_decorator.timeout(30, timeout_exception=PittServerDownException)
+    @timeout_decorator.timeout(30, timeout_exception=PittServerError)
     def test_lab_get_status_lawrence(self):
         self.assertIsInstance(lab.get_status("LAWRENCE"), dict)
 
-    @timeout_decorator.timeout(30, timeout_exception=PittServerDownException)
+    @timeout_decorator.timeout(30, timeout_exception=PittServerError)
     def test_lab_get_status_hillman(self):
         self.assertIsInstance(lab.get_status("HILLMAN"), dict)
 
-    @timeout_decorator.timeout(30, timeout_exception=PittServerDownException)
+    @timeout_decorator.timeout(30, timeout_exception=PittServerError)
     def test_lab_get_status_sutherland(self):
         self.assertIsInstance(lab.get_status("SUTH"), dict)

--- a/tests/lab_test.py
+++ b/tests/lab_test.py
@@ -34,6 +34,9 @@ class LabTest(unittest.TestCase):
     def test_get_status_sutherland(self):
         self.assertIsInstance(lab.get_status("SUTH"), dict)
 
+    def test_fetch_labs(self):
+        self.assertIsInstance(lab._fetch_labs(), list)
+
     def test_lab_name_validation(self):
         valid, fake = lab.LOCATIONS[0].lower(), 'test'
         self.assertTrue(lab._validate_lab(valid), lab.LOCATIONS[0])


### PR DESCRIPTION
## New Package Changes
- Insecure Request Warning is now ignored in `__init__.py` so no longer does it need to be called inside of every API.
- `get_class_description` returns a dictionary instead of a string, this makes the web wrapper nicer to develop but not sure if to keep this change. **Would like some feedback on this**.
- Optimized imports across all APIs.
- Updated Docs README.md now including the two new APIs in the list.

## Lab API Refactoring Changes
- Introduced usage of _list/tuple_ unpacking to make the code more readable.
  - `status, *machines = labs[LOCATIONS.index(lab_name)].split(':')` unpacking the status of the lab and machine totals.
  - `return _make_status('open', *_extract_machines(machines[0]))` unpacks the machine totals onto the parameters on `_make_status`.
- Lab API has been split up into a couple of functions, making it cleaner and easier to test with better testing coverage over the entire API. 
  - `_validate_lab` function quickly fixes case of the lab name and checks if valid, else returns a `ValueError`
  - `_make_status` is a new simple function for crafting the proper dictionary response, with defaults computer values being `0` making the calls very simple and clean.
- `URL` and `LOCATIONS` have been changed to be global and constant to the API.
- `LOCATIONS` is no longer a `dict` but a `list` since all the values were just indexes of the names.
- All functions are `PEP 257` compliant. #34
- Improvements made to the documentation.
  - Added new example to demonstrate how to use function and give examples of returning a closed lab and open lab.
  - Corrected list of labs and change `location_dict` to `LOCATIONS`
- New tests for private functions, improving coverage of code.
- Fetching data from website is now in its own function `_fetch_labs`.