### PR TITLE
CourseAPI: Get class method for retrieving class details.

### DIFF
--- a/PittAPI/course.py
+++ b/PittAPI/course.py
@@ -106,7 +106,7 @@ def _extract_course_data(header, course):
         return data
 
 
-def get_class_description(term, class_number):
+def get_class(term, class_number):
     """Return a string that is the description for class in a term"""
     payload = {
         'TERM': _validate_term(term),
@@ -115,7 +115,15 @@ def get_class_description(term, class_number):
     page = requests.get(URL + 'detail.asp', params=payload)
     if 'no courses by' in page.text or 'Search by subject' in page.text:
         raise ValueError('Invalid class number.')
-    soup = BeautifulSoup(page.text, 'lxml', parse_only=SoupStrainer(['td']))
-    return {
-        'description': soup.findAll('td', {'colspan': '9'})[1].text
-    }
+
+    description = _extract_description(page.text)
+    time = _extract_time(page.text)
+
+def _extract_description(text):
+    soup = BeautifulSoup(text, 'lxml', parse_only=SoupStrainer(['td']))
+    return soup.findAll('td', {'colspan': '9'})[1].text
+
+
+def _extract_time(text):
+    soup = BeautifulSoup(text, 'lxml', parse_only=SoupStrainer(['td']))
+    soup.findAll('td', {'class': 'style1'})

--- a/PittAPI/course.py
+++ b/PittAPI/course.py
@@ -117,10 +117,7 @@ def get_class(term, class_number):
     if 'no courses by' in page.text or 'Search by subject' in page.text:
         raise ValueError('Invalid class number.')
 
-    description = _extract_description(page.text)
-    details = _extract_details(page.text)
-
-    return dict(description, **details)
+    return dict(_extract_description(page.text), **_extract_details(page.text))
 
 
 def _extract_description(text):
@@ -134,10 +131,9 @@ def _extract_description(text):
 def _extract_details(text):
     """Extracts class number, classroom, section, date, and time from web page"""
     soup = BeautifulSoup(text, 'lxml', parse_only=SoupStrainer(['td']))
-    number, section, details = soup.findAll('td', {'class': 'style1'})[:3]
+    section, details = soup.findAll('td', {'class': 'style1'})[1:3]
     days, time, classroom = details.text.split(' / ')
     return {
-        'class_number': number.text.strip(),
         'section': section.text.strip(),
         'days': days,
         'time': time.split('-'),

--- a/PittAPI/course.py
+++ b/PittAPI/course.py
@@ -117,13 +117,23 @@ def get_class(term, class_number):
         raise ValueError('Invalid class number.')
 
     description = _extract_description(page.text)
-    time = _extract_time(page.text)
+    details = _extract_details(page.text)
+
+    return {**description, **details}
 
 def _extract_description(text):
     soup = BeautifulSoup(text, 'lxml', parse_only=SoupStrainer(['td']))
-    return soup.findAll('td', {'colspan': '9'})[1].text
+    return {
+        'description': soup.findAll('td', {'colspan': '9'})[1].text
+    }
 
 
-def _extract_time(text):
+def _extract_details(text):
     soup = BeautifulSoup(text, 'lxml', parse_only=SoupStrainer(['td']))
-    soup.findAll('td', {'class': 'style1'})
+    items = soup.findAll('td', {'class': 'style1'})
+    return {
+        'class_number': items[0].text,
+        'section': items[1].text,
+        'days': items[2].text,
+        'time': items[3].text
+    }

--- a/PittAPI/course.py
+++ b/PittAPI/course.py
@@ -107,6 +107,7 @@ def _extract_course_data(header, course):
 
 
 def get_class(term, class_number):
+    """Returns dictionary of details about a class."""
     payload = {
         'TERM': _validate_term(term),
         'CLASSNUM': class_number
@@ -123,20 +124,22 @@ def get_class(term, class_number):
 
 
 def _extract_description(text):
+    """Extracts class description from web page"""
     soup = BeautifulSoup(text, 'lxml', parse_only=SoupStrainer(['td']))
     return {
-        'description': soup.findAll('td', {'colspan': '9'})[1].text
+        'description': soup.findAll('td', {'colspan': '9'})[1].text.replace('\r\n', '')
     }
 
 
 def _extract_details(text):
+    """Extracts class number, classroom, section, date, and time from web page"""
     soup = BeautifulSoup(text, 'lxml', parse_only=SoupStrainer(['td']))
-    items = soup.findAll('td', {'class': 'style1'})[:3]
-    days, time, classroom = items[2].text.split('/')
+    number, section, details = soup.findAll('td', {'class': 'style1'})[:3]
+    days, time, classroom = details.text.split(' / ')
     return {
-        'class_number': items[0].text.strip(),
-        'section': items[1].text.strip(),
-        'days': days.strip(),
-        'time': time.strip(),
-        'classroom': classroom.strip()
+        'class_number': number.text.strip(),
+        'section': section.text.strip(),
+        'days': days,
+        'time': time.split('-'),
+        'classroom': classroom.replace('\xa0', ' ')
     }

--- a/PittAPI/course.py
+++ b/PittAPI/course.py
@@ -107,19 +107,20 @@ def _extract_course_data(header, course):
 
 
 def get_class(term, class_number):
-    """Return a string that is the description for class in a term"""
     payload = {
         'TERM': _validate_term(term),
         'CLASSNUM': class_number
     }
     page = requests.get(URL + 'detail.asp', params=payload)
+
     if 'no courses by' in page.text or 'Search by subject' in page.text:
         raise ValueError('Invalid class number.')
 
     description = _extract_description(page.text)
     details = _extract_details(page.text)
 
-    return {**description, **details}
+    return dict(description, **details)
+
 
 def _extract_description(text):
     soup = BeautifulSoup(text, 'lxml', parse_only=SoupStrainer(['td']))
@@ -130,10 +131,12 @@ def _extract_description(text):
 
 def _extract_details(text):
     soup = BeautifulSoup(text, 'lxml', parse_only=SoupStrainer(['td']))
-    items = soup.findAll('td', {'class': 'style1'})
+    items = soup.findAll('td', {'class': 'style1'})[:3]
+    days, time, classroom = items[2].text.split('/')
     return {
-        'class_number': items[0].text,
-        'section': items[1].text,
-        'days': items[2].text,
-        'time': items[3].text
+        'class_number': items[0].text.strip(),
+        'section': items[1].text.strip(),
+        'days': days.strip(),
+        'time': time.strip(),
+        'classroom': classroom.strip()
     }

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ from PittAPI import course, laundry, lab, dining
 big_dict = course.get_courses(term="2177", code="CS")
 # Will return a list of dictionaries containing courses that fulfill requirement
 big_dict = course.get_course(term="2177", code="Q")
-# Will return a string, which is the description of the course
-description = course.get_class_description(term="2177", class_number="10163")
+# Will return a dictionary with a details about the class
+description = course.get_Class(term="2177", class_number="10163")
 
 ### Laundry
 # Will return a dictionary with amount of washers and dryers

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ big_dict = course.get_courses(term="2177", code="CS")
 # Will return a list of dictionaries containing courses that fulfill requirement
 big_dict = course.get_course(term="2177", code="Q")
 # Will return a dictionary with a details about the class
-description = course.get_Class(term="2177", class_number="10163")
+description = course.get_class(term="2177", class_number="10163")
 
 ### Laundry
 # Will return a dictionary with amount of washers and dryers

--- a/docs/COURSE-API.md
+++ b/docs/COURSE-API.md
@@ -45,23 +45,34 @@ course.get_courses(term='2171', code='cs')
 
 ---
 
-### **get_class_description(class_number, term)**
+### **get_class(class_number, term)**
 
 #### **Parameters**:
   - `term`: Term number | Example: `"2171"`
   - `class_number`: Class Number | Example: `"18047"`
 
 #### **Returns**:
-Returns the description for `class_number` in `term`.
+Returns the details for `class_number` in `term`.
 
 #### **Example**:
 
 ###### **Code**:
 ```python
-course.get_class_description(term="2171", class_number="18047")
+course.get_class(term="2171", class_number="18047")
 ```
 
 ###### **Sample Output**:
 ```python
-u'This course will cover methods and strategies that are useful for the design of nonnumeric algorithms. Students are expected to design their own algorithms.'
+{'class_number': '26966',
+ 'classroom': '05502 SENSQ',
+ 'days': 'TuTh',
+ 'description': 'This is a first course in computer science programming. It is '
+                'recommended for those students intending to major in computer '
+                'science who do not have the required background for CS 0401. '
+                'It may also be of interest to students majoring in one of the '
+                'social sciences or humanities. The focus of the course is on '
+                'problem analysis and the development of algorithms and '
+                'computer programs in a modern high-level language.',
+ 'section': 'AT',
+ 'time': ['01:00 PM', '02:15 PM']}
 ```

--- a/docs/COURSE-API.md
+++ b/docs/COURSE-API.md
@@ -58,13 +58,12 @@ Returns the details for `class_number` in `term`.
 
 ###### **Code**:
 ```python
-course.get_class(term="2171", class_number="18047")
+course.get_class(term='2171', class_number='26966')
 ```
 
 ###### **Sample Output**:
 ```python
-{'class_number': '26966',
- 'classroom': '05502 SENSQ',
+{'classroom': '05502 SENSQ',
  'days': 'TuTh',
  'description': 'This is a first course in computer science programming. It is '
                 'recommended for those students intending to major in computer '

--- a/tests/course_test.py
+++ b/tests/course_test.py
@@ -52,13 +52,13 @@ class CourseTest(unittest.TestCase):
     def test_get_courses_sat_query(self):
         self.assertIsInstance(course.get_courses(TERM, course.SAT_PROGRAM), list)
 
-    # @timeout_decorator.timeout(DEFAULT_TIMEOUT, timeout_exception=PittServerError)
-    # def test_get_class_description(self):
-    #     self.assertIsInstance(course.get_class_description(TERM, '10045'), dict)
-    #
-    # @timeout_decorator.timeout(DEFAULT_TIMEOUT, timeout_exception=PittServerError)
-    # def test_invalid_class_number(self):
-    #     self.assertRaises(ValueError, course.get_class_description, TERM, '0')
+    @timeout_decorator.timeout(DEFAULT_TIMEOUT, timeout_exception=PittServerError)
+    def test_get_class_description(self):
+        self.assertIsInstance(course.get_class(TERM, '10045'), dict)
+
+    @timeout_decorator.timeout(DEFAULT_TIMEOUT, timeout_exception=PittServerError)
+    def test_invalid_class_number(self):
+        self.assertRaises(ValueError, course.get_class, TERM, '0')
 
     @timeout_decorator.timeout(DEFAULT_TIMEOUT, timeout_exception=PittServerError)
     def test_invalid_subject(self):
@@ -67,7 +67,7 @@ class CourseTest(unittest.TestCase):
     @timeout_decorator.timeout(DEFAULT_TIMEOUT, timeout_exception=PittServerError)
     def test_invalid_term(self):
         self.assertRaises(ValueError, course.get_courses, '1', 'CS')
-        # self.assertRaises(ValueError, course.get_class_description, '1', '10045')
+        self.assertRaises(ValueError, course.get_class, '1', '10045')
 
     def test_term_validation(self):
         self.assertEqual(course._validate_term('2177'), TERM)

--- a/tests/course_test.py
+++ b/tests/course_test.py
@@ -52,13 +52,13 @@ class CourseTest(unittest.TestCase):
     def test_get_courses_sat_query(self):
         self.assertIsInstance(course.get_courses(TERM, course.SAT_PROGRAM), list)
 
-    @timeout_decorator.timeout(DEFAULT_TIMEOUT, timeout_exception=PittServerError)
-    def test_get_class_description(self):
-        self.assertIsInstance(course.get_class_description(TERM, '10045'), dict)
-
-    @timeout_decorator.timeout(DEFAULT_TIMEOUT, timeout_exception=PittServerError)
-    def test_invalid_class_number(self):
-        self.assertRaises(ValueError, course.get_class_description, TERM, '0')
+    # @timeout_decorator.timeout(DEFAULT_TIMEOUT, timeout_exception=PittServerError)
+    # def test_get_class_description(self):
+    #     self.assertIsInstance(course.get_class_description(TERM, '10045'), dict)
+    #
+    # @timeout_decorator.timeout(DEFAULT_TIMEOUT, timeout_exception=PittServerError)
+    # def test_invalid_class_number(self):
+    #     self.assertRaises(ValueError, course.get_class_description, TERM, '0')
 
     @timeout_decorator.timeout(DEFAULT_TIMEOUT, timeout_exception=PittServerError)
     def test_invalid_subject(self):
@@ -67,7 +67,7 @@ class CourseTest(unittest.TestCase):
     @timeout_decorator.timeout(DEFAULT_TIMEOUT, timeout_exception=PittServerError)
     def test_invalid_term(self):
         self.assertRaises(ValueError, course.get_courses, '1', 'CS')
-        self.assertRaises(ValueError, course.get_class_description, '1', '10045')
+        # self.assertRaises(ValueError, course.get_class_description, '1', '10045')
 
     def test_term_validation(self):
         self.assertEqual(course._validate_term('2177'), TERM)


### PR DESCRIPTION
As a suggestion made by @JohnLinahan, `get_class_description` will become `get_class` with more details which include time, classrooms, days, section, etc.

## New Package Changes
- Updated README.md to reflected the changes made to CourseAPI

## New CourseAPI Changes
- `get_class_description` has become `get_class` with new functionality.
- There are now two private functions for data extraction.
  - `_extract_description(text)` which grabs the description of the course from the web page
  - `_extract_details(text)` which grabs the line of details about the certain class
    - This includes time, classroom, days, and section
- Updated documentation and added new example