### PR TITLE
one line fix for people.py, now works properly

### DIFF
--- a/PittAPI/people.py
+++ b/PittAPI/people.py
@@ -34,7 +34,6 @@ def get_person(query, max_people=10):
 
     return persons[:max_people]
 
-
 def _extract_person(item):
     """ """
     person = {
@@ -62,7 +61,6 @@ def _get_person_details(url):
 
 def _get_person_url(query, max_people):
     """ """
-    query = query.replace(' ', '+')
     request_objs = []
 
     for i in range(int(max_people / 10) + 1):


### PR DESCRIPTION
removed the line  ``` query = query.replace(' ', '+')```, this isn't necessary for the payload format and has been causing the api to return an empty list for all queries with spaces like ```people.get_person('daniel zheng')```