### PR TITLE
Fixing issue with News Alerts

### DIFF
--- a/PittAPI/news.py
+++ b/PittAPI/news.py
@@ -61,6 +61,7 @@ def get_news(feed='main_news', max_news_items=10):
             if fields["type"] == "loadMore":
                 continue
 
+            # TODO: Look into why this gives a Type Error during the news alert test.
             try:
                 title = fields["title"]
                 url = "https://m.pitt.edu" + fields["url"]["formatted"]

--- a/PittAPI/news.py
+++ b/PittAPI/news.py
@@ -61,9 +61,12 @@ def get_news(feed='main_news', max_news_items=10):
             if fields["type"] == "loadMore":
                 continue
 
-            title = fields["title"]
-            url = "https://m.pitt.edu" + fields["url"]["formatted"]
-            news.append({'title': title, 'url': url})
+            try:
+                title = fields["title"]
+                url = "https://m.pitt.edu" + fields["url"]["formatted"]
+                news.append({'title': title, 'url': url})
+            except TypeError:
+                continue
 
     return news[:max_news_items]
 


### PR DESCRIPTION
There has been a consistent error occurring in the build logs through off our stability. There error occurs in the News Test and is shown below

```python
======================================================================
ERROR: test_get_news_alerts (tests.news_test.NewsTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/Pitt-CSC/PittAPI/venv/lib/python3.5/site-packages/timeout_decorator/timeout_decorator.py", line 69, in new_function
    return function(*args, **kwargs)
  File "/home/travis/build/Pitt-CSC/PittAPI/tests/news_test.py", line 48, in test_get_news_alerts
    self.assertIsInstance(news.get_news("news_alerts"), list)
  File "/home/travis/build/Pitt-CSC/PittAPI/PittAPI/news.py", line 65, in get_news
    url = "https://m.pitt.edu" + fields["url"]["formatted"]
TypeError: 'NoneType' object is not subscriptable
-------------------- >> begin captured logging << --------------------
requests.packages.urllib3.connectionpool: DEBUG: Starting new HTTPS connection (1): m.pitt.edu
requests.packages.urllib3.connectionpool: DEBUG: https://m.pitt.edu:443 "GET /news/index.json?feed=news_alerts&start=0&id=&_object=kgoui_Rcontent_I0_Rcontent_I0 HTTP/1.1" 200 2154
--------------------- >> end captured logging << ---------------------
```

So far I just added a catch for when there is a type error to prevent this test from failing for now.