### PR TITLE
New course term validation method

### DIFF
--- a/PittAPI/course.py
+++ b/PittAPI/course.py
@@ -23,7 +23,6 @@ import re
 from bs4 import BeautifulSoup, SoupStrainer
 
 URL = 'http://www.courses.as.pitt.edu/'
-
 CODES = [
     'ADMPS', 'AFRCNA', 'ANTH', 'ARABIC', 'ASL', 'ARTSC', 'ASTRON', 'BIOETH', 'BIOSC', 'CHEM', 'CHLIT', 'CHIN', 'CLASS',
     'COMMRC', 'CS', 'EAS', 'ECON', 'ENGCMP', 'ENGFLM', 'ENGLIT', 'ENGWRT', 'FP', 'FR', 'FTDA', 'FTDB', 'FTDC', 'GEOL',
@@ -37,14 +36,6 @@ CODES = [
 REQUIREMENTS = ['G', 'W', 'Q', 'LIT', 'MA', 'EX', 'PH', 'SS', 'HS', 'NS', 'L', 'IF', 'IFN', 'I', 'A']
 PROGRAMS = ['CLST', 'ENV', 'FILMST', 'MRST', 'URBNST', 'SELF', 'GSWS']
 DAY_PROGRAM, SAT_PROGRAM = 'CGSDAY', 'CGSSAT'
-
-def _retrieve_term_codes():
-    """Returns a list of all current term codes from course web page."""
-    page = requests.get(URL)
-    soup = BeautifulSoup(page.text, 'lxml', parse_only=SoupStrainer(['input'])).findAll('input')
-    return [tag.attrs['value'] for tag in soup[:3]]
-
-TERMS = _retrieve_term_codes()
 
 def get_courses(term, code):
     """Returns a list of dictionaries containing all courses queried from code."""
@@ -73,10 +64,8 @@ def _get_subject_query(code, term):
 
 def _validate_term(term):
     """Validates term is a string and check if it is valid."""
-    if not isinstance(term, str):
-        warnings.warn('Term value should be a string.')
-        term = str(term)
-    if TERMS.match(term):
+    months = [1, 4 ,7]
+    if int(term / 1000) == 2 and (term % 10) in months:
         return term
     raise ValueError("Invalid term")
 

--- a/PittAPI/lab.py
+++ b/PittAPI/lab.py
@@ -28,11 +28,8 @@ URL = 'http://labinformation.cssd.pitt.edu/'
 
 def get_status(lab_name):
     """Returns a dictionary with status and amount of OS machines."""
-    status = None
-    machines = None
-    while not status and not machines:
-        lab_name, labs = _validate_lab(lab_name), _fetch_labs()
-        status, *machines = labs[LOCATIONS.index(lab_name)].split(':')
+    lab_name, labs = _validate_lab(lab_name), _fetch_labs()
+    status, *machines = labs[LOCATIONS.index(lab_name)].split(':')
 
     if 'open' in status:
         return _make_status('open', *_extract_machines(machines[0]))
@@ -43,7 +40,7 @@ def get_status(lab_name):
 def _fetch_labs():
     """Fetches text of status/machines of all labs."""
     text = ''
-    while not text:
+    while "Lab" not in text:
         page = session.get(URL)
         soup = BeautifulSoup(page.text, 'lxml')
         text = soup.span.text


### PR DESCRIPTION
A simple change that makes testing terms really easy. This came from thinking about how the term code is structured and it's very simple.

-----
Take the current term code for fall of 2017 `2181`.  This code seems weird but it's simply a representation of date the term ends, which would be January 2018. So the `218` is the year and the `1` is the month the term ends. Making it simple that if the term code starts with 2 and ends with 1, 4, or 7 then we can assume quickly it could be a valid term.