### PR TITLE
Course API function name change

### DIFF
--- a/PittAPI/course.py
+++ b/PittAPI/course.py
@@ -1,4 +1,4 @@
-'''
+"""
 The Pitt API, to access workable data of the University of Pittsburgh
 Copyright (C) 2015 Ritwik Gupta
 
@@ -14,8 +14,8 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-'''
+51 /Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""
 import warnings
 
 import requests
@@ -39,13 +39,23 @@ REQUIREMENTS = ['G', 'W', 'Q', 'LIT', 'MA', 'EX', 'PH', 'SS', 'HS', 'NS', 'L', '
 PROGRAMS = ['CLST', 'ENV', 'FILMST', 'MRST', 'URBNST', 'SELF', 'GSWS']
 DAY_PROGRAM, SAT_PROGRAM = 'CGSDAY', 'CGSSAT'
 
-def get_courses(term: str, code: str) -> List[Dict[str,str]]:
-    """Returns a list of dictionaries containing all courses queried from code."""
+
+def get_classes(term: str, code: str) -> List[Dict[str, str]]:
+    """Returns a list of dictionaries containing all classes queried from code."""
     col_headers, course_data = _retrieve_courses_from_url(
         url=URL + _get_subject_query(code, term)
     )
     courses = [_extract_course_data(col_headers, course) for course in course_data]
     return courses
+
+
+def get_courses(term: str, code: str) -> List[Dict[str,str]]:
+    """Returns a list of dictionaries containing all class queried from code.
+    This is now deprecated since the name of the function doesn't accurately reflect
+    the data returned. Functionality will still be maintained till until a newer version
+    of the API."""
+    warnings.warn("Warning get_courses() is deprecated, please use get_classes() instead.")
+    return get_classes(term, code)
 
 
 def _get_subject_query(code: str, term: str) -> str:

--- a/PittAPI/course.py
+++ b/PittAPI/course.py
@@ -14,7 +14,7 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
-51 /Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 import warnings
 

--- a/docs/COURSE-API.md
+++ b/docs/COURSE-API.md
@@ -3,7 +3,7 @@
 
 # Course API
 
-### **get_courses(term, code)**
+### **get_classes(term, code)**
 
 #### **Parameters**:
   - `term`: Term number | Example: `2171`
@@ -79,4 +79,48 @@ course.get_class(term='2174', class_number='23138')
  'special_indicators': ['WRIT'],
  'term': '2174',
  'time': ['09:30 AM', '10:45 AM']}
+```
+
+---
+
+### Deprecated
+
+### **get_courses(term, code)**
+
+#### **Parameters**:
+  - `term`: Term number | Example: `2171`
+  - `code`: Subject\Program\Requirement abbreviation | Example: `CS`
+
+#### **Returns**:
+Returns a list of dictionaries containing the data for all SUBJECT classes in TERM
+
+#### **Example**:
+
+###### **Code**:
+```python
+course.get_courses(term='2171', code='cs')
+```
+
+###### **Sample Output**:
+```python
+[
+  {
+    'catalog_number': u'0004',
+    'class_number': u'10160',
+    'credits': u'3 cr.',
+    'instructor': u'Not Decided',
+    'subject': u'CS',
+    'term': u'2171 \xa0AT',
+    'title': u'Intro Computer Progrmmng-Basic' },
+  {
+    'catalog_number': u'1530',
+    'class_number': u'11526',
+    'credits': u'3 cr.',
+    'instructor': u'Laboon,William J',
+    'subject': u'CS',
+    'term': u'2171 \xa0AT',
+    'title': u'Software Engineering'
+    }
+]
+
 ```

--- a/tests/course_test.py
+++ b/tests/course_test.py
@@ -39,19 +39,19 @@ class CourseTest(unittest.TestCase):
             self.cs_class_data = ''.join(f.readlines())
 
     @responses.activate
-    def test_get_courses(self):
+    def test_get_classes(self):
         responses.add(responses.GET, 'http://www.courses.as.pitt.edu/results-subja.asp?TERM=2001&SUBJ=CS',
                       body=self.cs_data, status=200)
-        self.assertIsInstance(course.get_courses(TERM, 'CS'), list)
+        self.assertIsInstance(course.get_classes(TERM, 'CS'), list)
 
     def test_get_course_invalid_class_number(self):
         self.assertRaises(ValueError, course.get_class, TERM, '0')
 
     def test_get_course_invalid_subject(self):
-        self.assertRaises(ValueError, course.get_courses, TERM, 'AAA')
+        self.assertRaises(ValueError, course.get_classes, TERM, 'AAA')
 
     def test_get_course_invalid_term(self):
-        self.assertRaises(ValueError, course.get_courses, '1', 'CS')
+        self.assertRaises(ValueError, course.get_classes, '1', 'CS')
 
     @responses.activate
     def test_get_class(self):

--- a/tests/course_test.py
+++ b/tests/course_test.py
@@ -44,6 +44,12 @@ class CourseTest(unittest.TestCase):
                       body=self.cs_data, status=200)
         self.assertIsInstance(course.get_classes(TERM, 'CS'), list)
 
+    @responses.activate
+    def test_get_courses(self):
+        responses.add(responses.GET, 'http://www.courses.as.pitt.edu/results-subja.asp?TERM=2001&SUBJ=CS',
+                      body=self.cs_data, status=200)
+        self.assertIsInstance(course.get_courses(TERM, 'CS'), list)
+
     def test_get_course_invalid_class_number(self):
         self.assertRaises(ValueError, course.get_class, TERM, '0')
 

--- a/tests/course_test.py
+++ b/tests/course_test.py
@@ -50,13 +50,13 @@ class CourseTest(unittest.TestCase):
                       body=self.cs_data, status=200)
         self.assertIsInstance(course.get_courses(TERM, 'CS'), list)
 
-    def test_get_course_invalid_class_number(self):
+    def test_get_class_invalid_class_number(self):
         self.assertRaises(ValueError, course.get_class, TERM, '0')
 
-    def test_get_course_invalid_subject(self):
+    def test_get_classes_invalid_subject(self):
         self.assertRaises(ValueError, course.get_classes, TERM, 'AAA')
 
-    def test_get_course_invalid_term(self):
+    def test_get_classes_invalid_term(self):
         self.assertRaises(ValueError, course.get_classes, '1', 'CS')
 
     @responses.activate
@@ -70,8 +70,10 @@ class CourseTest(unittest.TestCase):
 
     def test_get_subject_query(self):
         self.assertEquals(course._get_subject_query(course.CODES[0], TERM), 'results-subja.asp?TERM=2001&SUBJ=ADMPS')
-        self.assertEquals(course._get_subject_query(course.PROGRAMS[0], TERM), 'results-subjspeciala.asp?TERM=2001&SUBJ=CLST')
-        self.assertEquals(course._get_subject_query(course.REQUIREMENTS[0], TERM), 'results-genedreqa.asp?TERM=2001&REQ=G')
+        self.assertEquals(course._get_subject_query(course.PROGRAMS[0], TERM),
+                          'results-subjspeciala.asp?TERM=2001&SUBJ=CLST')
+        self.assertEquals(course._get_subject_query(course.REQUIREMENTS[0], TERM),
+                          'results-genedreqa.asp?TERM=2001&REQ=G')
         self.assertEquals(course._get_subject_query(course.DAY_PROGRAM, TERM), 'results-dayCGSa.asp?TERM=2001')
         self.assertEquals(course._get_subject_query(course.SAT_PROGRAM, TERM), 'results-satCGSa.asp?TERM=2001')
 


### PR DESCRIPTION
During a coding interview, the interviewer pointed out the confusion that `get_courses` has. Because, based on the name, it should probably return all the courses available within a subject. But instead, we give all the classes that are available for the term.

So I simply changed the function from `get_courses` to `get_classes`. With this, I maintained that `get_courses` will still work but now will throw a warning to the developer to switch over. I think in a future version of this API we should return the results of peoplesoft mobile's course catalog since it would better reflect what `get_course` should return.