### PR TITLE
new people API

### DIFF
--- a/PittAPI/people.py
+++ b/PittAPI/people.py
@@ -17,61 +17,56 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 '''
 
-import urllib.parse
-
 import grequests
 from typing import List, Dict, Iterator, Any
 
 PEOPLE_URL = "https://m.pitt.edu/people/search.json"
 DETAIL_URL = "https://m.pitt.edu/people/detail.json"
 
-
-def get_person(query: str, max_people: int = 10) -> List[Dict[str,Any]]:
-    """ """
-    url_list = [item for l_list in _get_person_url(query, max_people) for item in l_list]
-    results = [_get_person_details(url) for url in url_list]
-    people_info = [resp.json()["response"] for resp in grequests.map(results)]
+def get_person(query: str, max_people: int=10) -> List[Dict[str,Any]]:
+    """ Returns a list of people """
+    id_list = [item for l_list in _get_person_id(query, max_people) for item in l_list]
+    results = [_get_person_details(id) for id in id_list]
+    people_info = [resp.json() for resp in grequests.map(results)]
     persons = [_extract_person(person) for person in people_info]
 
     return persons[:max_people]
 
 def _extract_person(item: Dict[str,Any]) -> Dict[str,Any]:
-    """ """
+    """ Returns person attributes """
+    kgoui_person = item['response']['regions'][0]['contents'][0]['fields'] \
+                       ['item']['value']['kgoDeflatedData']['attributes']
+
     person = {
-        'name': item["fields"]["title"],
-        'fields': {}
+        'name': ''
     }
-
-    for tree in item["regions"][1]["contents"]:
-        tree = tree["regions"][0]["contents"][0]["fields"]
-        person["fields"].update({tree["label"]: tree['title']})
-
-    return person
+    return kgoui_person
 
 
-def _get_person_details(url: str):
-    """ """
+
+def _get_person_details(id_number: str):
+    """ Returns unsent request """
     payload = {
-        "id": url,
-        "_object": "kgoui_Rcontent_I0_Rcontent_I1",
-        "_object_include_html": 1
+        "search": "Search",
+        "id": id_number,
+        "_kgoui_object": "kgoui_Rcontent_I0_Rcontent_I1",
     }
     payload_str = "&".join("{}={}".format(k, v) for k, v in payload.items())
     return grequests.get(DETAIL_URL, params=payload_str)
 
 
-def _get_person_url(query: str, max_people: int) -> List[Iterator[str]]:
-    """ """
+def _get_person_id(query: str, max_people: int) -> List[Iterator[str]]:
+    """ Returns list of people IDs """
     request_objs = []
 
     for i in range(int(max_people / 10) + 1):
         payload = {
             "search": "Search",
             "filter": query,
-            "_region": "kgoui_Rcontent_I0_Rcontent_I0_Ritems",
+            "_kgoui_region": "kgoui_Rcontent_I0_Rcontent_I0_Ritems",
             "_object_include_html": 1,
             "_object_js_config": 1,
-            "_kgoui_page_state": "8c6ef035807a2a969576d6d78d211c78",
+            "_kgoui_page_state": "439a1a9b6fb81b480ade61813e20e049",
             "_region_index_offset": i * 10,
             "feed": "directory",
             "start": i * 10
@@ -84,9 +79,8 @@ def _get_person_url(query: str, max_people: int) -> List[Iterator[str]]:
     for response_obj in responses:
         response = response_obj.json()['response']['contents']
         local_url_list = (x['fields']['url']['formatted'] for x in response)
-        local_url_list = (x.replace('\\', '').split('&')[-1].replace('id=', '')
-                          for x in local_url_list if '&start' not in x)
-        local_url_list = (urllib.parse.unquote(x) for x in local_url_list)
+        local_url_list = (dict(param.split("=") for param in x.split("&"))
+                          for x in local_url_list)
+        local_url_list = (x['id'] for x in local_url_list if 'id' in x)
         url_list.append(local_url_list)
-
     return url_list

--- a/PittAPI/people.py
+++ b/PittAPI/people.py
@@ -26,7 +26,7 @@ FIELD_MAP = {
     "ldap:cn" : "name",
     "ldap:buildingname": "address",
     "kgoperson:phone" : "phone",
-    "ldap:ou" : "school",
+    "ldap:ou" : "department",
     "kgoperson:email" : "email",
     "ldap:url" : "webpage",
     "ldap:nickname" : "nickname",

--- a/PittAPI/people.py
+++ b/PittAPI/people.py
@@ -22,6 +22,15 @@ from typing import List, Dict, Iterator, Any
 
 PEOPLE_URL = "https://m.pitt.edu/people/search.json"
 DETAIL_URL = "https://m.pitt.edu/people/detail.json"
+FIELD_MAP = {
+    "ldap:cn" : "name",
+    "ldap:buildingname": "address",
+    "kgoperson:phone" : "phone",
+    "ldap:ou" : "school",
+    "kgoperson:email" : "email",
+    "ldap:url" : "webpage",
+    "ldap:nickname" : "nickname",
+}
 
 def get_person(query: str, max_people: int=10) -> List[Dict[str,Any]]:
     """ Returns a list of people """
@@ -37,10 +46,8 @@ def _extract_person(item: Dict[str,Any]) -> Dict[str,Any]:
     kgoui_person = item['response']['regions'][0]['contents'][0]['fields'] \
                        ['item']['value']['kgoDeflatedData']['attributes']
 
-    person = {
-        'name': ''
-    }
-    return kgoui_person
+    person = {FIELD_MAP[key]:kgoui_person[key] for key in kgoui_person if key in FIELD_MAP}
+    return person
 
 
 

--- a/PittAPI/people.py
+++ b/PittAPI/people.py
@@ -46,7 +46,7 @@ def _extract_person(item: Dict[str,Any]) -> Dict[str,Any]:
     kgoui_person = item['response']['regions'][0]['contents'][0]['fields'] \
                        ['item']['value']['kgoDeflatedData']['attributes']
 
-    person = {FIELD_MAP[key]:kgoui_person[key] for key in kgoui_person if key in FIELD_MAP}
+    person = {FIELD_MAP[key]:kgoui_person[key].strip() for key in kgoui_person if key in FIELD_MAP}
     return person
 
 

--- a/docs/PEOPLE-API.md
+++ b/docs/PEOPLE-API.md
@@ -25,21 +25,12 @@ people.get_person('Jane')
 [
   {
     "name": "Jane Doe",
-    "fields": [
-      {
-        "unit": "Dietrich Sch Arts and Sciences"
-      }
-    ]
+    "email": "jdoe@pitt.edu",
+    "phone": "(999)999-999"
   },
   {
     "name": "Janedo Smith",
-    "fields": [
-      {
-        "email": "doesnotexist@pitt.edu"
-      },
-      {
-        "unit": "School of Dental Medicine"
-      }
+    "school": "School of Dental Medicine"
     ]
   },
   ...


### PR DESCRIPTION
While trying to fix the API (#85), I found that we can actually some additional information previously only available at http://find.pitt.edu (like nickname + webpage), not just what is displayed when searching using https://m.pitt.edu/people/. I originally thought this information was only accessible through LDAP, so this is great. However, the new endpoint is still missing some data available on http://find.pitt.edu like "Student Career" and "Student Plan(s)", etc. so maybe there is a better one.

I've updated `people.py` to get this new data and will update tests and documentation once I decide how to format the output. 

For `people.get_person('John Smith', 1)` we can now get:
```
[{'kgoperson:phone': '(412)648-8362 ', 
'kgoperson:firstname': 'John', 
'ldap:nickname': 'RX2020', 
'kgoperson:email': 'jsmithjr@pitt.edu', 
'ldap:objectclass': ['person', 'top', 'PittPerson'], 
'kgo:id': 'uidNumber=3951,o=University of Pittsburgh,c=US', 
'kgo:title': 'John Smith', 
'ldap:buildingname': '250 SALK', 
'ldap:cn': 'John H Smith Jr', 
'ldap:ou': 'Pharm-Dean, Office of the', 
'ldap:l': 'Pittsburgh', 
'kgoperson:lastname': 'Smith'}]
```