### PR TITLE
Switching usage of os.path to pathlib

### DIFF
--- a/tests/course_test.py
+++ b/tests/course_test.py
@@ -17,7 +17,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 
-
 import unittest
 import responses
 
@@ -28,16 +27,16 @@ from bs4 import BeautifulSoup
 from PittAPI import course
 
 TERM = 2001
-SAMPLE_PATH = Path() / 'samples'
+SAMPLE_PATH = Path() / 'tests' / 'samples'
 HEADER_DATA = '<th width="9%">Subject</th><th>Catalog #</th><th>Credits/Units</th>'
 
 
 class CourseTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         unittest.TestCase.__init__(self, *args, **kwargs)
-        with open(SAMPLE_PATH / 'course_cs.html') as f:
+        with (SAMPLE_PATH / 'course_cs.html').open() as f:
             self.cs_data = ''.join(f.readlines())
-        with open(SAMPLE_PATH / 'course_class_cs.html') as f:
+        with (SAMPLE_PATH / 'course_class_cs.html').open() as f:
             self.cs_class_data = ''.join(f.readlines())
 
     @responses.activate

--- a/tests/course_test.py
+++ b/tests/course_test.py
@@ -28,7 +28,7 @@ from bs4 import BeautifulSoup
 from PittAPI import course
 
 TERM = 2001
-SAMPLE_PATH = Path('..') / 'samples'
+SAMPLE_PATH = Path('.').parent / 'samples'
 HEADER_DATA = '<th width="9%">Subject</th><th>Catalog #</th><th>Credits/Units</th>'
 
 

--- a/tests/course_test.py
+++ b/tests/course_test.py
@@ -28,7 +28,7 @@ from bs4 import BeautifulSoup
 from PittAPI import course
 
 TERM = 2001
-SAMPLE_PATH = Path('.').parent / 'samples'
+SAMPLE_PATH = Path('.') / 'samples'
 HEADER_DATA = '<th width="9%">Subject</th><th>Catalog #</th><th>Credits/Units</th>'
 
 

--- a/tests/course_test.py
+++ b/tests/course_test.py
@@ -28,7 +28,7 @@ from bs4 import BeautifulSoup
 from PittAPI import course
 
 TERM = 2001
-SAMPLE_PATH = Path.cwd() / 'samples'
+SAMPLE_PATH = Path.cwd() / 'tests' / 'samples'
 HEADER_DATA = '<th width="9%">Subject</th><th>Catalog #</th><th>Credits/Units</th>'
 
 

--- a/tests/course_test.py
+++ b/tests/course_test.py
@@ -17,25 +17,27 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 
-import os
+
 import unittest
 import responses
+
+from pathlib import Path
 
 from bs4 import BeautifulSoup
 
 from PittAPI import course
 
 TERM = 2001
-SCRIPT_PATH = os.path.dirname(__file__)
+SAMPLE_PATH = Path.cwd() / 'samples'
 HEADER_DATA = '<th width="9%">Subject</th><th>Catalog #</th><th>Credits/Units</th>'
 
 
 class CourseTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         unittest.TestCase.__init__(self, *args, **kwargs)
-        with open(os.path.join(SCRIPT_PATH, 'samples', 'course_cs.html')) as f:
+        with open(SAMPLE_PATH / 'course_cs.html') as f:
             self.cs_data = ''.join(f.readlines())
-        with open(os.path.join(SCRIPT_PATH, 'samples', 'course_class_cs.html')) as f:
+        with open(SAMPLE_PATH / 'course_class_cs.html') as f:
             self.cs_class_data = ''.join(f.readlines())
 
     @responses.activate

--- a/tests/course_test.py
+++ b/tests/course_test.py
@@ -28,7 +28,7 @@ from bs4 import BeautifulSoup
 from PittAPI import course
 
 TERM = 2001
-SAMPLE_PATH = Path('.') / 'samples'
+SAMPLE_PATH = Path() / 'samples'
 HEADER_DATA = '<th width="9%">Subject</th><th>Catalog #</th><th>Credits/Units</th>'
 
 

--- a/tests/course_test.py
+++ b/tests/course_test.py
@@ -28,7 +28,7 @@ from bs4 import BeautifulSoup
 from PittAPI import course
 
 TERM = 2001
-SAMPLE_PATH = Path.cwd() / 'tests' / 'samples'
+SAMPLE_PATH = Path('..') / 'samples'
 HEADER_DATA = '<th width="9%">Subject</th><th>Catalog #</th><th>Credits/Units</th>'
 
 

--- a/tests/dining_test.py
+++ b/tests/dining_test.py
@@ -25,13 +25,13 @@ from pathlib import Path
 
 from PittAPI import dining
 
-SAMPLE_PATH = Path() / 'samples'
+SAMPLE_PATH = Path() / 'tests' / 'samples'
 
 
 class DiningTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         unittest.TestCase.__init__(self, *args, **kwargs)
-        with open(SAMPLE_PATH / 'dining.json') as f:
+        with (SAMPLE_PATH / 'dining.json').open() as f:
             self.dining_data = json.load(f)
 
     @responses.activate

--- a/tests/dining_test.py
+++ b/tests/dining_test.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 from PittAPI import dining
 
-SAMPLE_PATH = Path.cwd() / 'tests' / 'samples'
+SAMPLE_PATH = Path('..') / 'samples'
 
 
 class DiningTest(unittest.TestCase):

--- a/tests/dining_test.py
+++ b/tests/dining_test.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 from PittAPI import dining
 
-SAMPLE_PATH = Path('.') / 'samples'
+SAMPLE_PATH = Path() / 'samples'
 
 
 class DiningTest(unittest.TestCase):

--- a/tests/dining_test.py
+++ b/tests/dining_test.py
@@ -18,19 +18,20 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 """
 
 import json
-import os
 import unittest
 import responses
 
+from pathlib import Path
+
 from PittAPI import dining
 
-SCRIPT_PATH = os.path.dirname(__file__)
+SAMPLE_PATH = Path.cwd() / 'samples'
 
 
 class DiningTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         unittest.TestCase.__init__(self, *args, **kwargs)
-        with open(os.path.join(SCRIPT_PATH, 'samples', 'dining.json')) as f:
+        with open(SAMPLE_PATH / 'dining.json') as f:
             self.dining_data = json.load(f)
 
     @responses.activate

--- a/tests/dining_test.py
+++ b/tests/dining_test.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 from PittAPI import dining
 
-SAMPLE_PATH = Path.cwd() / 'samples'
+SAMPLE_PATH = Path.cwd() / 'tests' / 'samples'
 
 
 class DiningTest(unittest.TestCase):

--- a/tests/dining_test.py
+++ b/tests/dining_test.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 from PittAPI import dining
 
-SAMPLE_PATH = Path('.').parent / 'samples'
+SAMPLE_PATH = Path('.') / 'samples'
 
 
 class DiningTest(unittest.TestCase):

--- a/tests/dining_test.py
+++ b/tests/dining_test.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 from PittAPI import dining
 
-SAMPLE_PATH = Path('..') / 'samples'
+SAMPLE_PATH = Path('.').parent / 'samples'
 
 
 class DiningTest(unittest.TestCase):

--- a/tests/laundry_test.py
+++ b/tests/laundry_test.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 from PittAPI import laundry
 
-SAMPLE_PATH = Path('..') / 'samples'
+SAMPLE_PATH = Path('.').parent / 'samples'
 TEST_BUILDING = list(laundry.LOCATION_LOOKUP.keys())[0]
 
 

--- a/tests/laundry_test.py
+++ b/tests/laundry_test.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 from PittAPI import laundry
 
-SAMPLE_PATH = Path.cwd() / 'samples'
+SAMPLE_PATH = Path.cwd() / 'tests' / 'samples'
 TEST_BUILDING = list(laundry.LOCATION_LOOKUP.keys())[0]
 
 

--- a/tests/laundry_test.py
+++ b/tests/laundry_test.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 from PittAPI import laundry
 
-SAMPLE_PATH = Path.cwd() / 'tests' / 'samples'
+SAMPLE_PATH = Path('..') / 'samples'
 TEST_BUILDING = list(laundry.LOCATION_LOOKUP.keys())[0]
 
 

--- a/tests/laundry_test.py
+++ b/tests/laundry_test.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 from PittAPI import laundry
 
-SAMPLE_PATH = Path('.') / 'samples'
+SAMPLE_PATH = Path() / 'samples'
 TEST_BUILDING = list(laundry.LOCATION_LOOKUP.keys())[0]
 
 

--- a/tests/laundry_test.py
+++ b/tests/laundry_test.py
@@ -24,14 +24,14 @@ from pathlib import Path
 
 from PittAPI import laundry
 
-SAMPLE_PATH = Path() / 'samples'
+SAMPLE_PATH = Path() / 'tests' / 'samples'
 TEST_BUILDING = list(laundry.LOCATION_LOOKUP.keys())[0]
 
 
 class LaundryTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         unittest.TestCase.__init__(self, *args, **kwargs)
-        with open(SAMPLE_PATH / 'laundry.htm') as f:
+        with (SAMPLE_PATH / 'laundry.htm').open() as f:
             self.laundry_data = ''.join(f.readlines())
 
     @responses.activate

--- a/tests/laundry_test.py
+++ b/tests/laundry_test.py
@@ -17,20 +17,21 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 
-import os
 import unittest
 import responses
 
+from pathlib import Path
+
 from PittAPI import laundry
 
-SCRIPT_PATH = os.path.dirname(__file__)
+SAMPLE_PATH = Path.cwd() / 'samples'
 TEST_BUILDING = list(laundry.LOCATION_LOOKUP.keys())[0]
 
 
 class LaundryTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         unittest.TestCase.__init__(self, *args, **kwargs)
-        with open(os.path.join(SCRIPT_PATH, 'samples/laundry.htm')) as f:
+        with open(SAMPLE_PATH / 'laundry.htm') as f:
             self.laundry_data = ''.join(f.readlines())
 
     @responses.activate

--- a/tests/laundry_test.py
+++ b/tests/laundry_test.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 from PittAPI import laundry
 
-SAMPLE_PATH = Path('.').parent / 'samples'
+SAMPLE_PATH = Path('.') / 'samples'
 TEST_BUILDING = list(laundry.LOCATION_LOOKUP.keys())[0]
 
 

--- a/tests/status_test.py
+++ b/tests/status_test.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 from PittAPI import status
 
-SAMPLE_PATH = Path('..') / 'samples'
+SAMPLE_PATH = Path('.').parent / 'samples'
 
 
 class StatusTest(unittest.TestCase):

--- a/tests/status_test.py
+++ b/tests/status_test.py
@@ -31,7 +31,7 @@ SAMPLE_PATH = Path() / 'tests' / 'samples'
 class StatusTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         unittest.TestCase.__init__(self, *args, **kwargs)
-        with (SAMPLE_PATH / 'status.json').open as f:
+        with (SAMPLE_PATH / 'status.json').open() as f:
             self.status_data = json.load(f)
 
     @responses.activate

--- a/tests/status_test.py
+++ b/tests/status_test.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 from PittAPI import status
 
-SAMPLE_PATH = Path.cwd() / 'samples'
+SAMPLE_PATH = Path.cwd() / 'tests' / 'samples'
 
 
 class StatusTest(unittest.TestCase):

--- a/tests/status_test.py
+++ b/tests/status_test.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 from PittAPI import status
 
-SAMPLE_PATH = Path('.').parent / 'samples'
+SAMPLE_PATH = Path('.') / 'samples'
 
 
 class StatusTest(unittest.TestCase):

--- a/tests/status_test.py
+++ b/tests/status_test.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 from PittAPI import status
 
-SAMPLE_PATH = Path.cwd() / 'tests' / 'samples'
+SAMPLE_PATH = Path('..') / 'samples'
 
 
 class StatusTest(unittest.TestCase):

--- a/tests/status_test.py
+++ b/tests/status_test.py
@@ -18,19 +18,20 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 """
 
 import json
-import os
 import unittest
 import responses
 
+from pathlib import Path
+
 from PittAPI import status
 
-SCRIPT_PATH = os.path.dirname(__file__)
+SAMPLE_PATH = Path.cwd() / 'samples'
 
 
 class StatusTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         unittest.TestCase.__init__(self, *args, **kwargs)
-        with open(os.path.join(SCRIPT_PATH, 'samples', 'status.json')) as f:
+        with open(SAMPLE_PATH / 'status.json') as f:
             self.status_data = json.load(f)
 
     @responses.activate

--- a/tests/status_test.py
+++ b/tests/status_test.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 from PittAPI import status
 
-SAMPLE_PATH = Path('.') / 'samples'
+SAMPLE_PATH = Path() / 'samples'
 
 
 class StatusTest(unittest.TestCase):

--- a/tests/status_test.py
+++ b/tests/status_test.py
@@ -25,13 +25,13 @@ from pathlib import Path
 
 from PittAPI import status
 
-SAMPLE_PATH = Path() / 'samples'
+SAMPLE_PATH = Path() / 'tests' / 'samples'
 
 
 class StatusTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         unittest.TestCase.__init__(self, *args, **kwargs)
-        with open(SAMPLE_PATH / 'status.json') as f:
+        with (SAMPLE_PATH / 'status.json').open as f:
             self.status_data = json.load(f)
 
     @responses.activate

--- a/tests/textbook_test.py
+++ b/tests/textbook_test.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from PittAPI import textbook
 
 TERM = '1000'
-SAMPLE_PATH = Path() / 'samples'
+SAMPLE_PATH = Path() / 'tests' / 'samples'
 
 print(SAMPLE_PATH.absolute())
 
@@ -36,9 +36,9 @@ class TextbookTest(unittest.TestCase):
         unittest.TestCase.__init__(self, *args, **kwargs)
         self.validate_term = textbook._validate_term
         self.validate_course = textbook._validate_course
-        with open(SAMPLE_PATH /'textbook_courses_CS.json') as f:
+        with (SAMPLE_PATH /'textbook_courses_CS.json').open() as f:
             self.cs_data = json.load(f)
-        with open(SAMPLE_PATH / 'textbook_courses_STAT.json') as f:
+        with (SAMPLE_PATH / 'textbook_courses_STAT.json').open() as f:
             self.stat_data = json.load(f)
 
     @responses.activate

--- a/tests/textbook_test.py
+++ b/tests/textbook_test.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from PittAPI import textbook
 
 TERM = '1000'
-SAMPLE_PATH = Path.cwd() / 'tests' / 'samples'
+SAMPLE_PATH = Path('..') / 'samples'
 
 class TextbookTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):

--- a/tests/textbook_test.py
+++ b/tests/textbook_test.py
@@ -26,7 +26,10 @@ from pathlib import Path
 from PittAPI import textbook
 
 TERM = '1000'
-SAMPLE_PATH = Path('.') / 'samples'
+SAMPLE_PATH = Path() / 'samples'
+
+print(SAMPLE_PATH.absolute())
+
 
 class TextbookTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):

--- a/tests/textbook_test.py
+++ b/tests/textbook_test.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from PittAPI import textbook
 
 TERM = '1000'
-SAMPLE_PATH = Path('.').parent / 'samples'
+SAMPLE_PATH = Path('.') / 'samples'
 
 class TextbookTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):

--- a/tests/textbook_test.py
+++ b/tests/textbook_test.py
@@ -19,23 +19,23 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 import responses
 import json
-import os
 import unittest
+
+from pathlib import Path
 
 from PittAPI import textbook
 
 TERM = '1000'
-SCRIPT_PATH = os.path.dirname(__file__)
-
+SAMPLE_PATH = Path.cwd() / 'samples'
 
 class TextbookTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         unittest.TestCase.__init__(self, *args, **kwargs)
         self.validate_term = textbook._validate_term
         self.validate_course = textbook._validate_course
-        with open(os.path.join(SCRIPT_PATH, 'samples/textbook_courses_CS.json')) as f:
+        with open(SAMPLE_PATH /'textbook_courses_CS.json') as f:
             self.cs_data = json.load(f)
-        with open(os.path.join(SCRIPT_PATH, 'samples/textbook_courses_STAT.json')) as f:
+        with open(SAMPLE_PATH / 'textbook_courses_STAT.json') as f:
             self.stat_data = json.load(f)
 
     @responses.activate

--- a/tests/textbook_test.py
+++ b/tests/textbook_test.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from PittAPI import textbook
 
 TERM = '1000'
-SAMPLE_PATH = Path.cwd() / 'samples'
+SAMPLE_PATH = Path.cwd() / 'tests' / 'samples'
 
 class TextbookTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):

--- a/tests/textbook_test.py
+++ b/tests/textbook_test.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from PittAPI import textbook
 
 TERM = '1000'
-SAMPLE_PATH = Path('..') / 'samples'
+SAMPLE_PATH = Path('.').parent / 'samples'
 
 class TextbookTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Simple refactoring of tests to use `pathlib` to reach samples then `os.path`