### PR TITLE
Disable non-mocked tests in GitHub workflows

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -31,6 +31,6 @@ jobs:
       - name: Run all tests with pytest
         run: |
           pytest --cov=pittapi tests/
-          --ignore=tests/lab_test.py
-          --ignore=tests/library_test.py
-          --ignore=tests/people_test.py
+            --ignore=tests/lab_test.py
+            --ignore=tests/library_test.py
+            --ignore=tests/people_test.py

--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -31,6 +31,6 @@ jobs:
       - name: Run all tests with pytest
         run: |
           pytest --cov=pittapi tests/
-
-    
-
+          --ignore=tests/lab_test.py
+          --ignore=tests/library_test.py
+          --ignore=tests/people_test.py

--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -29,8 +29,7 @@ jobs:
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Run all tests with pytest
-        run: |
-          pytest --cov=pittapi tests/
+        run: pytest --cov=pittapi tests/
             --ignore=tests/lab_test.py
             --ignore=tests/library_test.py
             --ignore=tests/people_test.py

--- a/.github/workflows/tests-on-push.yml
+++ b/.github/workflows/tests-on-push.yml
@@ -35,3 +35,6 @@ jobs:
     - name: Test with pytest
       run: |
         pytest --cov=pittapi tests/
+        --ignore=tests/lab_test.py
+        --ignore=tests/library_test.py
+        --ignore=tests/people_test.py

--- a/.github/workflows/tests-on-push.yml
+++ b/.github/workflows/tests-on-push.yml
@@ -33,8 +33,7 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
-      run: |
-        pytest --cov=pittapi tests/
+      run: pytest --cov=pittapi tests/
           --ignore=tests/lab_test.py
           --ignore=tests/library_test.py
           --ignore=tests/people_test.py

--- a/.github/workflows/tests-on-push.yml
+++ b/.github/workflows/tests-on-push.yml
@@ -35,6 +35,6 @@ jobs:
     - name: Test with pytest
       run: |
         pytest --cov=pittapi tests/
-        --ignore=tests/lab_test.py
-        --ignore=tests/library_test.py
-        --ignore=tests/people_test.py
+          --ignore=tests/lab_test.py
+          --ignore=tests/library_test.py
+          --ignore=tests/people_test.py


### PR DESCRIPTION
Contributes to #166

Temporarily disables tests/lab_test.py, tests/library_test.py, and tests/people_test.py for automated testing with pytest for GitHub workflows. This is because the tests in those files make real HTTP requests and do not mock their inputs, and this is causing those tests to fail on all incoming PRs (see issue #166). These tests should be reenaabled once they are rewritten to properly mock their inputs.