### PR TITLE
Clean up unused/unnecessary imports

### DIFF
--- a/pittapi/cal.py
+++ b/pittapi/cal.py
@@ -17,7 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 
-from typing import List, NamedTuple
+from typing import NamedTuple
 
 import requests
 
@@ -36,7 +36,7 @@ COURSE_CALENDAR_URL: str = "https://25livepub.collegenet.com/calendars/pitt-cour
 GRADUATION_CALENDAR_URL: str = "https://25livepub.collegenet.com/calendars/pitt-graduation-calendar.json"
 
 
-def _fetch_calendar_events(url: str) -> List[Event]:
+def _fetch_calendar_events(url: str) -> list[Event]:
     """"""
     data = requests.get(url).json()
     events = []
@@ -52,27 +52,27 @@ def _fetch_calendar_events(url: str) -> List[Event]:
     return events
 
 
-def get_academic_calendar() -> List[Event]:
+def get_academic_calendar() -> list[Event]:
     """"""
     return _fetch_calendar_events(ACADEMIC_CALENDAR_URL)
 
 
-def get_grades_calendar() -> List[Event]:
+def get_grades_calendar() -> list[Event]:
     """"""
     return _fetch_calendar_events(GRADES_CALENDAR_URL)
 
 
-def get_enrollment_calendar() -> List[Event]:
+def get_enrollment_calendar() -> list[Event]:
     """"""
     return _fetch_calendar_events(ENROLLMENT_CALENDAR_URL)
 
 
-def get_course_calendar() -> List[Event]:
+def get_course_calendar() -> list[Event]:
     """This is not a calendar about course schedule but rather
     when courses/class are being determined for the next semester"""
     return _fetch_calendar_events(COURSE_CALENDAR_URL)
 
 
-def get_graduation_calendar() -> List[Event]:
+def get_graduation_calendar() -> list[Event]:
     """"""
     return _fetch_calendar_events(GRADUATION_CALENDAR_URL)

--- a/pittapi/lab.py
+++ b/pittapi/lab.py
@@ -17,10 +17,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 
-from typing import List, NamedTuple
-
-from requests_html import HTMLSession
-from parse import compile
 import requests
 import urllib3
 

--- a/pittapi/laundry.py
+++ b/pittapi/laundry.py
@@ -18,10 +18,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 """
 
 import requests
-import re
-from typing import Any, Dict, List, Union
+from typing import Any
 
-from bs4 import BeautifulSoup
 
 BASE_URL = "https://www.laundryview.com/api/currentRoomData?school_desc_key=197&location={}"
 
@@ -46,7 +44,7 @@ def _get_laundry_info(building_name: str) -> Any:
     return info
 
 
-def get_status_simple(building_name: str) -> Dict[str, str]:
+def get_status_simple(building_name: str) -> dict[str, str]:
     """
     :returns: a dictionary with free washers and dryers as well as total washers
               and dryers for given building
@@ -90,7 +88,7 @@ def get_status_simple(building_name: str) -> Dict[str, str]:
     }
 
 
-def get_status_detailed(building_name: str) -> List[Dict[str, Union[str, int]]]:
+def get_status_detailed(building_name: str) -> list[dict[str, str | int]]:
     """
     :returns: A list of washers and dryers for the passed
               building location with their statuses

--- a/pittapi/library.py
+++ b/pittapi/library.py
@@ -19,7 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 import requests
 from html.parser import HTMLParser
-from typing import Any, Dict, List
+from typing import Any
 
 LIBRARY_URL = (
     "https://pitt.primo.exlibrisgroup.com/primaws/rest/pub/pnxs"
@@ -50,7 +50,7 @@ class HTMLStrip(HTMLParser):
         return "".join(self.data)
 
 
-def get_documents(query: str, page: int = 1) -> Dict[str, Any]:
+def get_documents(query: str, page: int = 1) -> dict[str, Any]:
     """Return ten resource results from the specified page"""
     parsed_query = query.replace(" ", "+")
     full_query = LIBRARY_URL + QUERY_START + parsed_query
@@ -61,7 +61,7 @@ def get_documents(query: str, page: int = 1) -> Dict[str, Any]:
     return results
 
 
-def get_document_by_bookmark(bookmark: str) -> Dict[str, Any]:
+def get_document_by_bookmark(bookmark: str) -> dict[str, Any]:
     """Return resource referenced by bookmark"""
     payload = {"bookMark": bookmark}
     resp = sess.get(LIBRARY_URL, params=payload)
@@ -81,7 +81,7 @@ def _strip_html(html: str) -> str:
     return strip.get_data()
 
 
-def _extract_results(json: Dict[str, Any]) -> Dict[str, Any]:
+def _extract_results(json: dict[str, Any]) -> dict[str, Any]:
     results = {
         "total_results": json["info"]["total"],
         "pages": json["info"]["last"],
@@ -90,7 +90,7 @@ def _extract_results(json: Dict[str, Any]) -> Dict[str, Any]:
     return results
 
 
-def _extract_documents(documents: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def _extract_documents(documents: list[dict[str, Any]]) -> list[dict[str, Any]]:
     new_docs = []
     keep_keys = {
         "title",
@@ -119,8 +119,8 @@ def _extract_documents(documents: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return new_docs
 
 
-def _extract_facets(facet_fields: List[Dict[str, Any]]) -> Dict[str, List[Dict[str, Any]]]:
-    facets = {}  # type: Dict[str,List[Dict[str,Any]]]
+def _extract_facets(facet_fields: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    facets: dict[str, list[dict[str, Any]]] = {}
     for facet in facet_fields:
         facets[facet["display_name"]] = []
         for count in facet["counts"]:

--- a/pittapi/news.py
+++ b/pittapi/news.py
@@ -17,11 +17,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 
-import re
 import math
 import requests
 import grequests
-from typing import Dict, List, Any
+from typing import Any
 
 sess = requests.session()
 
@@ -44,7 +43,7 @@ def _load_n_items(feed: str, max_news_items: int):
     return responses
 
 
-def get_news(feed: str = "main_news", max_news_items: int = 10) -> List[Dict[str, Any]]:
+def get_news(feed: str = "main_news", max_news_items: int = 10) -> list[dict[str, Any]]:
     # feed indicates the desired news feed
     # 'main_news'      - main news
     # 'cssd'           - student announcements, on my pitt

--- a/pittapi/people.py
+++ b/pittapi/people.py
@@ -18,8 +18,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 """
 
 from requests_html import HTMLSession
-from typing import List, Dict
-from parse import compile
 
 # Please note that find.pitt.edu will not accept more than 10 requests within a few minutes
 # It will time out if that happens
@@ -43,7 +41,7 @@ LABEL_CONVERSION = {
 }
 
 
-def _parse_segments(person: dict, segments: List[str]) -> None:
+def _parse_segments(person: dict, segments: list[str]) -> None:
     label = None
     for segment in segments:
         if "class" in segment.attrs and "row-label" in segment.attrs["class"]:
@@ -62,7 +60,7 @@ def _parse_segments(person: dict, segments: List[str]) -> None:
                 person[label] = segment.text
 
 
-def get_person(query: str) -> List[Dict[str, str]]:
+def get_person(query: str) -> list[dict[str, str]]:
     payload = {"search": query}
     session = HTMLSession()
     resp = session.post(PEOPLE_SEARCH_URL, data=payload)

--- a/pittapi/shuttle.py
+++ b/pittapi/shuttle.py
@@ -18,12 +18,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 """
 
 import requests
-from typing import List, Dict, Any
+from typing import Any
 
 sess = requests.session()
 
 
-def get_map_vehicle_points(api_key: str = "8882812681") -> Dict[str, Any]:
+def get_map_vehicle_points(api_key: str = "8882812681") -> dict[str, Any]:
     """Return the map location for all active vehicles."""
     payload = {"ApiKey": api_key}
     response = sess.get(
@@ -33,7 +33,7 @@ def get_map_vehicle_points(api_key: str = "8882812681") -> Dict[str, Any]:
     return response.json()
 
 
-def get_route_stop_arrivals(api_key: str = "8882812681", times_per_stop: int = 1) -> Dict[str, Any]:
+def get_route_stop_arrivals(api_key: str = "8882812681", times_per_stop: int = 1) -> dict[str, Any]:
     """Return stop arrival times for all vehicles."""
     payload = {"ApiKey": api_key, "TimesPerStopString": times_per_stop}
     response = sess.get(
@@ -43,7 +43,7 @@ def get_route_stop_arrivals(api_key: str = "8882812681", times_per_stop: int = 1
     return response.json()
 
 
-def get_vehicle_route_stop_estimates(vehicle_id: str, quantity: int = 2) -> Dict[str, Any]:
+def get_vehicle_route_stop_estimates(vehicle_id: str, quantity: int = 2) -> dict[str, Any]:
     """Return {quantity} stop estimates for all active vehicles."""
     payload = {"vehicleIdStrings": vehicle_id, "quantity": str(quantity)}
     response = sess.get(
@@ -53,7 +53,7 @@ def get_vehicle_route_stop_estimates(vehicle_id: str, quantity: int = 2) -> Dict
     return response.json()
 
 
-def get_routes(api_key: str = "8882812681") -> Dict[str, Any]:
+def get_routes(api_key: str = "8882812681") -> dict[str, Any]:
     """Return the routes with Vehicle Route Name, Vehicle ID, and all stops, etc."""
     payload = {"ApiKey": api_key}
     response = sess.get(

--- a/pittapi/status.py
+++ b/pittapi/status.py
@@ -18,10 +18,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 """
 
 import requests
-from typing import Dict, List, Any
+from typing import Any
 
 
-def get_status() -> Dict[str, List[Any]]:
+def get_status() -> dict[str, list[Any]]:
     """Gets status information about all Pitt services"""
     status = requests.get("https://status.pitt.edu/index.json")
     data = status.json()

--- a/pittapi/textbook.py
+++ b/pittapi/textbook.py
@@ -1,7 +1,7 @@
 import grequests
 import requests
 
-from typing import List, Dict, Any, Callable, Generator, Tuple
+from typing import Any, Callable, Generator
 
 BASE_URL = "http://pitt.verbacompare.com/"
 
@@ -252,14 +252,14 @@ def _validate_course(course: str) -> str:
     return "0" * (4 - len(course)) + course
 
 
-def _filter_dictionary(d: Dict[Any, Any], keys: List[Any]) -> Dict[Any, Any]:
+def _filter_dictionary(d: dict[Any, Any], keys: list[Any]) -> dict[Any, Any]:
     """Creates new dictionary from selecting certain
     key value pairs from another dictionary
     """
     return dict((k, d[k]) for k in keys if k in d)
 
 
-def _find_item(id_key, data_key, error_item) -> Callable[[Dict[Any, Any], Any], Any]:
+def _find_item(id_key, data_key, error_item) -> Callable[[dict[Any, Any], Any], Any]:
     """Finds a dictionary in a list based on its id key, and
     returns a piece of data from the dictionary based on a data key.
     """
@@ -297,7 +297,7 @@ def _extract_id(response, course: str, instructor: str, section: str) -> str:
     raise LookupError("Unable to find course by " + LOOKUP_ERRORS[error].format(section, instructor))
 
 
-def _extract_books(ids: List[str]) -> List[Dict[str, str]]:
+def _extract_books(ids: list[str]) -> list[dict[str, str]]:
     """Fetches a course's textbook information and returns a list
     of textbooks for the given course.
     """
@@ -314,8 +314,8 @@ class DefaultDict(dict):
 
 
 def _fetch_course(
-    courses: List[Dict[str, str]], departments: Dict[str, str]
-) -> Generator[Tuple[str, str, str, str], None, None]:
+    courses: list[dict[str, str]], departments: dict[str, str]
+) -> Generator[tuple[str, str, str, str], None, None]:
     """Generator for fetching a courses information in order"""
     for course in courses:
         course = DefaultDict(course)
@@ -340,7 +340,7 @@ def _get_department_number(department_code: str) -> int:
     return department_number
 
 
-def get_textbooks(term: str, courses: List[Dict[str, str]]) -> List[Dict[str, str]]:
+def get_textbooks(term: str, courses: list[dict[str, str]]) -> list[dict[str, str]]:
     """Retrieves textbooks for multiple courses in the same term."""
     departments = {course["department"] for course in courses}
     responses = grequests.map(
@@ -367,7 +367,7 @@ def get_textbooks(term: str, courses: List[Dict[str, str]]) -> List[Dict[str, st
     return _extract_books(section_ids)
 
 
-def get_textbook(term: str, department: str, course: str, instructor: str = None, section: str = None) -> List[Dict[str, str]]:
+def get_textbook(term: str, department: str, course: str, instructor: str = None, section: str = None) -> list[dict[str, str]]:
     """Retrieves textbooks for a given course."""
     has_section_or_instructor = (instructor is not None) or (section is not None)
     if not has_section_or_instructor:

--- a/tests/course_test.py
+++ b/tests/course_test.py
@@ -21,7 +21,7 @@ import unittest
 from unittest.mock import MagicMock
 
 from pittapi import course
-from pittapi.course import Attribute, Component, Course, CourseDetails, Instructor, Meeting, Section, SectionDetails, Subject
+from pittapi.course import Attribute, Course, CourseDetails, Instructor, Meeting, Section, SectionDetails, Subject
 from tests.mocks.course_mocks import (
     mocked_subject_data,
     mocked_courses_data,

--- a/tests/lab_test.py
+++ b/tests/lab_test.py
@@ -18,7 +18,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 """
 
 import unittest
-import responses
 
 from pittapi import lab
 


### PR DESCRIPTION
- Clean up unused imports throughout codebase
- Replace most type hint imports from `typing` package with built-in type hints (e.g., `List` -> `list`, `Optional[str]` -> `str | None`)

My goal with this import cleanup is to prepare the repo for a similar cleanup for the project dependencies: it's harder to tell which packages aren't actually required as dependencies if some packages are imported but never used.