### PR TITLE
Add caching to GitHub Actions workflows

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -16,6 +16,13 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: "3.12"
+      # https://github.com/actions/cache/blob/main/examples.md#python---pip
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/tests-on-push.yml
+++ b/.github/workflows/tests-on-push.yml
@@ -19,6 +19,13 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: "3.12"
+    # https://github.com/actions/cache/blob/main/examples.md#python---pip
+    - uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Exactly what the title says, see https://github.com/marketplace/actions/cache

Assuming this works, this could significantly cut down on the runtime of our workflows by caching our dependencies