### PR TITLE
Fix build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pitt API
 
-![Build Status](https://img.shields.io/github/actions/workflow/status/pittcsc/PittAPI/tests-on-push.yml?branch=dev)
+![Build Status](https://img.shields.io/github/actions/workflow/status/pittcsc/PittAPI/autotest.yml?branch=dev)
 ![License](https://img.shields.io/badge/license-GPLv2-blue.svg)
 ![Python Version](https://img.shields.io/badge/python-%3E%3D%203.9-green.svg)
 


### PR DESCRIPTION
The build status badge was broken when the GH Actions workflow was renamed in #180 from `tests-on-push` to `autotest`