### PR TITLE
Reenable `tests/people_test.py`

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -42,4 +42,3 @@ jobs:
         run: black --line-length=127 --check --diff .
       - name: Run all tests with pytest
         run: pytest --cov=pittapi tests/
-            --ignore=tests/people_test.py


### PR DESCRIPTION
Broken tests for `people.py` were fixed in #158, so this file can be added back to the GH Actions autotest workflow