### PR TITLE
Update imports in `pittapi/__init__.py`

### DIFF
--- a/pittapi/__init__.py
+++ b/pittapi/__init__.py
@@ -17,7 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 
-import requests
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
+import urllib3
+from urllib3.exceptions import InsecureRequestWarning
 
-requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+urllib3.disable_warnings(InsecureRequestWarning)


### PR DESCRIPTION
Update `pittapi/__init__.py` to import `urllib3` rather than `requests.packages.urllib3`. The previous method of disabling `InsecureRequestWarning` is now outdated and raises import errors with mypy (see https://stackoverflow.com/a/28002687).