### PR TITLE
Fix `mypy` errors in `lab.py`

### DIFF
--- a/pittapi/lab.py
+++ b/pittapi/lab.py
@@ -52,7 +52,7 @@ class Lab(NamedTuple):
 class LabAPIError(Exception):
     """Raised when an error occurs while accessing the Lab API."""
 
-    def __init__(self, message):
+    def __init__(self, message: str):
         super().__init__(message)
 
 


### PR DESCRIPTION
Run `mypy` with `--strict` flag and fix errors in `lab.py` due to a missing type hint

Contributes to #45 by fixing existing type hint errors prior to introducing `mypy` to the repo.

Before:
```
> mypy --strict pittapi/lab.py 
pittapi/lab.py:55: error: Function is missing a type annotation  [no-untyped-def]
pittapi/lab.py:84: error: Call to untyped function "LabAPIError" in typed context  [no-untyped-call]
pittapi/lab.py:86: error: Call to untyped function "LabAPIError" in typed context  [no-untyped-call]
Found 3 errors in 1 file (checked 1 source file)
```

After:
```
> mypy --strict pittapi/lab.py
Success: no issues found in 1 source file
```