### PR TITLE
Monkey-patch `ssl` in `__init__` to fix `grequests` warning/error

### DIFF
--- a/pittapi/__init__.py
+++ b/pittapi/__init__.py
@@ -17,6 +17,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 
+# grequests monkey-patches ssl, but this must be done before all other imports,
+# or else we may get a MonkeyPatchWarning or a RecursionError
+# See https://github.com/spyoungtech/grequests/issues/150 and https://github.com/gevent/gevent/issues/1016
+from gevent import monkey
+
+monkey.patch_all(thread=False, select=False)
+
 import urllib3
 from urllib3.exceptions import InsecureRequestWarning
 


### PR DESCRIPTION
The `grequests` package monkey-patches `ssl` upon import, but this must be done before all other imports. This PR imports `gevent` at the very top of `__init__.py` and explicitly monkey-patches everything.

Currently, without this patch, importing the `news` module will raise a `MonkeyPatchWarning`:
```py
>>> from pittapi import news
.../lib/python3.12/site-packages/grequests.py:22: MonkeyPatchWarning: Monkey-patching ssl after ssl has already been imported may lead to errors, including RecursionError on Python 3.6. It may also silently lead to incorrect behaviour on Python 3.7. Please monkey-patch earlier. See https://github.com/gevent/gevent/issues/1016. Modules that had direct imports (NOT patched): [...]. 
  curious_george.patch_all(thread=False, select=False)
```
while importing `textbook` will raise this warning as well as a `RecursionError`:
```py
>>> from pittapi import textbook
.../lib/python3.12/site-packages/grequests.py:22: MonkeyPatchWarning: Monkey-patching ssl after ssl has already been imported may lead to errors, including RecursionError on Python 3.6. It may also silently lead to incorrect behaviour on Python 3.7. Please monkey-patch earlier. See https://github.com/gevent/gevent/issues/1016. Modules that had direct imports (NOT patched): [...]. 
  curious_george.patch_all(thread=False, select=False)
Traceback (most recent call last):
...
RecursionError: maximum recursion depth exceeded
```
With this patch, both modules can be imported with no warnings or errors.

References:
- https://github.com/spyoungtech/grequests/issues/150
- https://github.com/gevent/gevent/issues/1016