### PR TITLE
Fix `mypy` errors and rename `NamedTuple` fields in `gym.py`

### DIFF
--- a/pittapi/gym.py
+++ b/pittapi/gym.py
@@ -39,16 +39,16 @@ GYM_NAMES = [
 
 class Gym(NamedTuple):
     name: str
-    last_updated: str | None
-    current_count: int | None
-    percent_full: int | None
+    last_updated: str | None = None
+    current_count: int | None = None
+    percent_full: int | None = None
 
     @classmethod
     def from_text(cls, text: str) -> Gym:
         info = text.split("|")
         name = info[0]
         if len(info) < 4:
-            return cls(name=name, last_updated=None, current_count=None, percent_full=None)
+            return cls(name=name)
         count = int(info[2][12:])
         date_time = info[3][9:]
         try:

--- a/pittapi/gym.py
+++ b/pittapi/gym.py
@@ -39,24 +39,24 @@ GYM_NAMES = [
 
 class Gym(NamedTuple):
     name: str
-    date: str
-    count: int
-    percentage: int
+    last_updated: str | None
+    current_count: int | None
+    percent_full: int | None
 
     @classmethod
     def from_text(cls, text: str) -> Gym:
         info = text.split("|")
         name = info[0]
         if len(info) < 4:
-            return cls(name=name, date=None, count=None, percentage=None)
+            return cls(name=name, last_updated=None, current_count=None, percent_full=None)
         count = int(info[2][12:])
-        date = info[3][9:]
+        date_time = info[3][9:]
         try:
             percentage = int(info[4].rstrip("%"))
         except ValueError:
             percentage = 0
 
-        return cls(name=name, date=date, count=count, percentage=percentage)
+        return cls(name=name, last_updated=date_time, current_count=count, percent_full=percentage)
 
 
 def get_all_gyms_info() -> list[Gym]:
@@ -71,7 +71,6 @@ def get_all_gyms_info() -> list[Gym]:
     soup = BeautifulSoup(page.text, "html.parser")
     gym_info_list = soup.find_all("div", class_="barChart")
 
-    # Iterate through list and add to dictionary
     gyms = [Gym.from_text(gym.get_text("|", strip=True)) for gym in gym_info_list]
     return gyms
 
@@ -81,6 +80,6 @@ def get_gym_info(gym_name: str) -> Gym | None:
     info = get_all_gyms_info()
     if gym_name in GYM_NAMES:
         for gym in info:
-            if gym.name == gym_name and gym.date and gym.count and gym.percentage:
+            if gym.name == gym_name and gym.last_updated and gym.current_count and gym.percent_full:
                 return gym
     return None

--- a/tests/gym_test.py
+++ b/tests/gym_test.py
@@ -15,19 +15,24 @@ class GymTest(unittest.TestCase):
 
         gym_info = gym.get_all_gyms_info()
         expected_info = [
-            gym.Gym(name="Baierl Rec Center", date="07/09/2024 09:05 AM", count=100, percentage=50),
-            gym.Gym(name="Bellefield Hall: Fitness Center & Weight Room", date="07/09/2024 09:05 AM", count=50, percentage=0),
-            gym.Gym(name="Bellefield Hall: Court & Dance Studio", date=None, count=None, percentage=None),
-            gym.Gym(name="Trees Hall: Fitness Center", date="07/09/2024 09:05 AM", count=70, percentage=58),
-            gym.Gym(name="Trees Hall: Courts", date="07/09/2024 09:05 AM", count=20, percentage=33),
+            gym.Gym(name="Baierl Rec Center", last_updated="07/09/2024 09:05 AM", current_count=100, percent_full=50),
+            gym.Gym(
+                name="Bellefield Hall: Fitness Center & Weight Room",
+                last_updated="07/09/2024 09:05 AM",
+                current_count=50,
+                percent_full=0,
+            ),
+            gym.Gym(name="Bellefield Hall: Court & Dance Studio", last_updated=None, current_count=None, percent_full=None),
+            gym.Gym(name="Trees Hall: Fitness Center", last_updated="07/09/2024 09:05 AM", current_count=70, percent_full=58),
+            gym.Gym(name="Trees Hall: Courts", last_updated="07/09/2024 09:05 AM", current_count=20, percent_full=33),
             gym.Gym(
                 name="Trees Hall: Racquetball Courts & Multipurpose Room",
-                date="07/09/2024 09:05 AM",
-                count=10,
-                percentage=25,
+                last_updated="07/09/2024 09:05 AM",
+                current_count=10,
+                percent_full=25,
             ),
-            gym.Gym(name="William Pitt Union", date="07/09/2024 09:05 AM", count=25, percentage=25),
-            gym.Gym(name="Pitt Sports Dome", date="07/09/2024 09:05 AM", count=15, percentage=20),
+            gym.Gym(name="William Pitt Union", last_updated="07/09/2024 09:05 AM", current_count=25, percent_full=25),
+            gym.Gym(name="Pitt Sports Dome", last_updated="07/09/2024 09:05 AM", current_count=15, percent_full=20),
         ]
 
         self.assertEqual(gym_info, expected_info)
@@ -37,7 +42,9 @@ class GymTest(unittest.TestCase):
         responses.add(responses.GET, gym.GYM_URL, body=mock_gym_html, status=200)
 
         gym_info = gym.get_gym_info("Baierl Rec Center")
-        expected_info = gym.Gym(name="Baierl Rec Center", date="07/09/2024 09:05 AM", count=100, percentage=50)
+        expected_info = gym.Gym(
+            name="Baierl Rec Center", last_updated="07/09/2024 09:05 AM", current_count=100, percent_full=50
+        )
         self.assertEqual(gym_info, expected_info)
 
     @responses.activate

--- a/tests/gym_test.py
+++ b/tests/gym_test.py
@@ -22,7 +22,7 @@ class GymTest(unittest.TestCase):
                 current_count=50,
                 percent_full=0,
             ),
-            gym.Gym(name="Bellefield Hall: Court & Dance Studio", last_updated=None, current_count=None, percent_full=None),
+            gym.Gym(name="Bellefield Hall: Court & Dance Studio"),
             gym.Gym(name="Trees Hall: Fitness Center", last_updated="07/09/2024 09:05 AM", current_count=70, percent_full=58),
             gym.Gym(name="Trees Hall: Courts", last_updated="07/09/2024 09:05 AM", current_count=20, percent_full=33),
             gym.Gym(


### PR DESCRIPTION
Contributes to #45 by fixing existing type hint errors prior to introducing `mypy` to the repo.

Run `mypy` with `--strict` flag and fix resulting `mypy` errors in `gym.py`.

Rename some fields in the `Gym` `NamedTuple` class in order to clarify their meanings and to fix a `mypy` error. The `count` field specifically causes a `mypy` error because `mypy` interprets the field's name as the `count` method that `NamedTuple` inherits from the base `tuple` class: According to the `mypy` devs, this is expected behavior and is not a bug:
- https://github.com/python/mypy/issues/4507
- https://github.com/python/mypy/issues/17047

Before:
```
> mypy --strict pittapi/gym.py        
pittapi/__init__.py:23: error: Skipping analyzing "gevent": module is installed, but missing library stubs or py.typed marker  [import-untyped]
pittapi/gym.py:22: error: Library stubs not installed for "bs4"  [import-untyped]
pittapi/gym.py:22: note: Hint: "python3 -m pip install types-beautifulsoup4"
pittapi/gym.py:22: note: (or run "mypy --install-types" to install all missing stub packages)
pittapi/gym.py:22: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
pittapi/gym.py:43: error: Incompatible types in assignment (expression has type "int", base class "tuple" defined the type as "Callable[[tuple[str | int, ...], Any], int]")  [assignment]
pittapi/gym.py:51: error: Argument "date" to "Gym" has incompatible type "None"; expected "str"  [arg-type]
pittapi/gym.py:51: error: Argument "count" to "Gym" has incompatible type "None"; expected "int"  [arg-type]
pittapi/gym.py:51: error: Argument "percentage" to "Gym" has incompatible type "None"; expected "int"  [arg-type]
Found 6 errors in 2 files (checked 1 source file)
```

After:
```
> mypy --strict pittapi/gym.py       
pittapi/__init__.py:23: error: Skipping analyzing "gevent": module is installed, but missing library stubs or py.typed marker  [import-untyped]
pittapi/gym.py:22: error: Library stubs not installed for "bs4"  [import-untyped]
pittapi/gym.py:22: note: Hint: "python3 -m pip install types-beautifulsoup4"
pittapi/gym.py:22: note: (or run "mypy --install-types" to install all missing stub packages)
pittapi/gym.py:22: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 2 errors in 2 files (checked 1 source file)
```
Like the remaining `mypy` errors from #193, we'll need to ignore these `missing-imports` errors with `--ignore-missing-imports`.