### PR TITLE
Refactor `library.py` to use `NamedTuple`, fix `mypy` errors

### DIFF
--- a/tests/library_test.py
+++ b/tests/library_test.py
@@ -43,9 +43,8 @@ class LibraryTest(unittest.TestCase):
             status=200,
         )
         query_result = library.get_documents("water")
-        self.assertIsInstance(query_result, dict)
-        self.assertEqual(query_result["pages"], 10)
-        self.assertEqual(len(query_result["docs"]), 10)
+        self.assertEqual(query_result.num_pages, 10)
+        self.assertEqual(len(query_result.docs), 10)
 
 
 class StudyRoomTest(unittest.TestCase):
@@ -62,7 +61,7 @@ class StudyRoomTest(unittest.TestCase):
             json=self.hillman_query,
             status=200,
         )
-        self.assertEqual(library.hillman_total_reserved(), {"Total Hillman Reservations": 4})
+        self.assertEqual(library.hillman_total_reserved(), 4)
 
     @responses.activate
     def test_reserved_hillman_times(self):
@@ -73,21 +72,25 @@ class StudyRoomTest(unittest.TestCase):
             status=200,
         )
         mock_answer = [
-            {
-                "Room": "408 HL (Max. 5 persons) (Enclosed Room)",
-                "Reserved": ["2024-06-12 17:30:00", "2024-06-12 20:30:00"],
-            },
-            {
-                "Room": "409 HL (Max. 5 persons) (Enclosed Room)",
-                "Reserved": ["2024-06-12 18:00:00", "2024-06-12 21:00:00"],
-            },
-            {
-                "Room": "303 HL (Max. 5 persons) (Enclosed Room)",
-                "Reserved": ["2024-06-12 18:30:00", "2024-06-12 21:30:00"],
-            },
-            {
-                "Room": "217 HL (Max. 10 persons) (Enclosed Room)",
-                "Reserved": ["2024-06-12 19:00:00", "2024-06-12 22:30:00"],
-            },
+            library.Reservation(
+                room="408 HL (Max. 5 persons) (Enclosed Room)",
+                reserved_from="2024-06-12 17:30:00",
+                reserved_until="2024-06-12 20:30:00",
+            ),
+            library.Reservation(
+                room="409 HL (Max. 5 persons) (Enclosed Room)",
+                reserved_from="2024-06-12 18:00:00",
+                reserved_until="2024-06-12 21:00:00",
+            ),
+            library.Reservation(
+                room="303 HL (Max. 5 persons) (Enclosed Room)",
+                reserved_from="2024-06-12 18:30:00",
+                reserved_until="2024-06-12 21:30:00",
+            ),
+            library.Reservation(
+                room="217 HL (Max. 10 persons) (Enclosed Room)",
+                reserved_from="2024-06-12 19:00:00",
+                reserved_until="2024-06-12 22:30:00",
+            ),
         ]
         self.assertEqual(mock_answer, library.reserved_hillman_times())


### PR DESCRIPTION
Contributes to #45 by fixing existing type hint errors prior to introducing `mypy` to the repo.

Refactor `library.py` to store API output using `NamedTuple`s rather than plain Python `dict`s. This makes the output more user-friendly, less error-prone, and easier to type-hint.

Before:
```
> mypy --strict pittapi/library.py
pittapi/__init__.py:23: error: Skipping analyzing "gevent": module is installed, but missing library stubs or py.typed marker  [import-untyped]
pittapi/__init__.py:23: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
pittapi/library.py:48: error: Function is missing a return type annotation  [no-untyped-def]
pittapi/library.py:48: note: Use "-> None" if function does not return a value
pittapi/library.py:86: error: Call to untyped function "HTMLStrip" in typed context  [no-untyped-call]
pittapi/library.py:145: error: Value of type "Response" is not indexable  [index]
pittapi/library.py:156: error: Value of type "Response" is not indexable  [index]
Found 5 errors in 2 files (checked 1 source file)
```

After:
```
> mypy --strict pittapi/library.py       
pittapi/__init__.py:23: error: Skipping analyzing "gevent": module is installed, but missing library stubs or py.typed marker  [import-untyped]
pittapi/__init__.py:23: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 1 source file)
```
Like in #193, the remaining `missing-imports` error will need to be ignored with `--ignore-missing-imports` because `gevent` simply doesn't provide any type hints for `mypy`.