### PR TITLE
Completely rewrite `news.py` and unit tests

### DIFF
--- a/tests/news_test.py
+++ b/tests/news_test.py
@@ -17,48 +17,213 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 
+import responses
 import unittest
+
+from pathlib import Path
 
 from pittapi import news
 
+SAMPLE_PATH = Path() / "tests" / "samples"
 
-@unittest.skip
+
 class NewsTest(unittest.TestCase):
-    def test_get_news_default(self):
-        self.assertIsInstance(news.get_news(), list)
+    def __init__(self, *args, **kwargs):
+        unittest.TestCase.__init__(self, *args, **kwargs)
+        with (SAMPLE_PATH / "news_university_news_features_articles_page_0.html").open() as f:
+            self.university_news_features_articles_page_0 = f.read()
+        with (SAMPLE_PATH / "news_university_news_features_articles_page_1.html").open() as f:
+            self.university_news_features_articles_page_1 = f.read()
+        with (SAMPLE_PATH / "news_university_news_features_articles_fulbright.html").open() as f:
+            self.university_news_features_articles_fulbright = f.read()
+        with (SAMPLE_PATH / "news_university_news_features_articles_2020.html").open() as f:
+            self.university_news_features_articles_2020 = f.read()
 
-    def test_get_news_main(self):
-        self.assertIsInstance(news.get_news("main_news"), list)
+    @responses.activate
+    def test_get_articles_by_topic(self):
+        responses.add(
+            responses.GET,
+            "https://www.pitt.edu/pittwire/news/features-articles?field_topics_target_id=432&field_article_date_value=&title="
+            "&field_category_target_id=All",
+            body=self.university_news_features_articles_page_0,
+        )
 
-    def test_get_news_cssd(self):
-        self.assertIsInstance(news.get_news("cssd"), list)
+        university_news_articles = news.get_articles_by_topic("university-news")
 
-    def test_get_news_chronicle(self):
-        self.assertIsInstance(news.get_news("news_chronicle"), list)
+        self.assertEqual(len(university_news_articles), news.NUM_ARTICLES_PER_PAGE)
+        self.assertEqual(
+            university_news_articles[0],
+            news.Article(
+                title="Questions for the ‘Connecting King’",
+                description="Vernard Alexander, the new director of Pitt’s Homewood Community Engagement Center, "
+                "sees himself as the ultimate connector.",
+                url="https://www.pitt.edu/pittwire/pittmagazine/features-articles/vernard-alexander-community-engagement",
+                tags=["University News", "Community Impact"],
+            ),
+        )
+        self.assertEqual(
+            university_news_articles[-1],
+            news.Article(
+                title="John Surma is Pitt’s 2024 spring commencement speaker",
+                description="The University will also honor the Board of Trustees member and former U. S. Steel CEO "
+                "with an honorary degree.",
+                url="https://www.pitt.edu/pittwire/features-articles/2024-spring-commencement-speaker-john-surma",
+                tags=["University News", "Commencement"],
+            ),
+        )
 
-    def test_get_news_alerts(self):
-        self.assertIsInstance(news.get_news("news_alerts"), list)
+    @responses.activate
+    def test_get_articles_by_topic_query(self):
+        query = "fulbright"
+        responses.add(
+            responses.GET,
+            "https://www.pitt.edu/pittwire/news/features-articles?field_topics_target_id=432&field_article_date_value="
+            f"&title={query}&field_category_target_id=All",
+            body=self.university_news_features_articles_fulbright,
+        )
 
-    def test_get_news_length_nine(self):
-        self.assertTrue(0 < len(news.get_news(max_news_items=9)) <= 9)
+        university_news_articles = news.get_articles_by_topic("university-news", query=query)
 
-    def test_get_news_length_ten(self):
-        self.assertTrue(0 < len(news.get_news(max_news_items=10)) <= 10)
+        self.assertEqual(len(university_news_articles), 3)
+        self.assertEqual(
+            university_news_articles[0],
+            news.Article(
+                title="Meet Pitt’s 2024 faculty Fulbright winners",
+                description="The Fulbright U.S. Scholar Program offers faculty the opportunity "
+                "to teach and conduct research abroad.",
+                url="https://www.pitt.edu/pittwire/features-articles/faculty-fulbright-scholars-2024",
+                tags=["University News", "Innovation and Research", "Global", "Faculty"],
+            ),
+        )
+        self.assertEqual(
+            university_news_articles[-1],
+            news.Article(
+                title="Pitt has been named a top producer of Fulbright U.S. students for 2022-23",
+                description="Meet the nine Pitt scholars in this year’s cohort.",
+                url="https://www.pitt.edu/pittwire/features-articles/pitt-fulbright-top-producing-institution-2022-2023",
+                tags=[
+                    "University News",
+                    "Global",
+                    "David C. Frederick Honors College",
+                    "Kenneth P. Dietrich School of Arts and Sciences",
+                    "School of Education",
+                    "Swanson School of Engineering",
+                ],
+            ),
+        )
 
-    def test_get_news_length_eleven(self):
-        self.assertTrue(0 < len(news.get_news(max_news_items=11)) <= 11)
+    @responses.activate
+    def test_get_articles_by_topic_year(self):
+        year = 2020
+        responses.add(
+            responses.GET,
+            f"https://www.pitt.edu/pittwire/news/features-articles?field_topics_target_id=432&field_article_date_value={year}"
+            "&title=&field_category_target_id=All",
+            body=self.university_news_features_articles_2020,
+        )
 
-    def test_get_news_length_twenty(self):
-        self.assertTrue(0 < len(news.get_news(max_news_items=20)) <= 20)
+        university_news_articles = news.get_articles_by_topic("university-news", year=year)
 
-    def test_get_news_length_twentyfive(self):
-        self.assertTrue(0 < len(news.get_news(max_news_items=25)) <= 25)
+        self.assertEqual(len(university_news_articles), 5)
+        self.assertEqual(
+            university_news_articles[0],
+            news.Article(
+                title="University of Pittsburgh Library System acquires archive of renowned playwright August Wilson",
+                description="The late playwright and Pittsburgh native is best known for his unprecedented "
+                "American Century Cycle—10 plays that convey the Black experience in each decade of the 20th century. "
+                "All 10 of the plays",
+                url="https://www.pitt.edu/pittwire/features-articles/university-pittsburgh-library-system-acquires-archive-"
+                "renowned-playwright-august-wilson",
+                tags=["University News", "Arts and Humanities"],
+            ),
+        )
+        self.assertEqual(
+            university_news_articles[-1],
+            news.Article(
+                title="Track and field Olympian reflects on time at Pitt and plans for new facilities",
+                description="Alumnus Herb Douglas (EDUC ’48, ’50G), the oldest living African American Olympic medalist, "
+                "says plans for new training spaces for athletes will bring recruiting and Pitt Athletics to new heights.",
+                url="https://www.pitt.edu/pittwire/features-articles/track-and-field-olympian-reflects-time-pitt-"
+                "plans-new-facilities",
+                tags=["University News", "Athletics"],
+            ),
+        )
 
-    def test_get_news_length_twentynine(self):
-        self.assertTrue(0 < len(news.get_news(max_news_items=29)) <= 29)
+    @responses.activate
+    def test_get_articles_by_topic_less_than_one_page(self):
+        num_results = 5
+        responses.add(
+            responses.GET,
+            "https://www.pitt.edu/pittwire/news/features-articles?field_topics_target_id=432&field_article_date_value=&title="
+            "&field_category_target_id=All",
+            body=self.university_news_features_articles_page_0,
+        )
 
-    def test_get_news_length_thirty(self):
-        self.assertTrue(0 < len(news.get_news(max_news_items=30)) <= 30)
+        university_news_articles = news.get_articles_by_topic("university-news", max_num_results=num_results)
 
-    def test_get_news_length_forty(self):
-        self.assertTrue(0 < len(news.get_news(max_news_items=40)) <= 40)
+        self.assertEqual(len(university_news_articles), num_results)
+        self.assertEqual(
+            university_news_articles[0],
+            news.Article(
+                title="Questions for the ‘Connecting King’",
+                description="Vernard Alexander, the new director of Pitt’s Homewood Community Engagement Center, "
+                "sees himself as the ultimate connector.",
+                url="https://www.pitt.edu/pittwire/pittmagazine/features-articles/vernard-alexander-community-engagement",
+                tags=["University News", "Community Impact"],
+            ),
+        )
+        self.assertEqual(
+            university_news_articles[-1],
+            news.Article(
+                title="Panthers Forward can now help graduates find loan forgiveness and repayment options",
+                description="Pitt’s innovative debt-relief program has partnered with Savi, "
+                "which can help some borrowers save thousands.",
+                url="https://www.pitt.edu/pittwire/features-articles/panthers-forward-savi-affordability",
+                tags=["University News", "Students"],
+            ),
+        )
+
+    @responses.activate
+    def test_get_articles_by_topic_multiple_pages(self):
+        num_results = news.NUM_ARTICLES_PER_PAGE + 5
+        responses.add(
+            responses.GET,
+            "https://www.pitt.edu/pittwire/news/features-articles?field_topics_target_id=432&field_article_date_value=&title="
+            "&field_category_target_id=All",
+            body=self.university_news_features_articles_page_0,
+        )
+        responses.add(
+            responses.GET,
+            "https://www.pitt.edu/pittwire/news/features-articles?field_topics_target_id=432&field_article_date_value=&title="
+            "&field_category_target_id=All&page=1",
+            body=self.university_news_features_articles_page_1,
+        )
+
+        university_news_articles = news.get_articles_by_topic("university-news", max_num_results=num_results)
+
+        self.assertEqual(len(university_news_articles), num_results)
+        self.assertEqual(
+            university_news_articles[0],
+            news.Article(
+                title="Questions for the ‘Connecting King’",
+                description="Vernard Alexander, the new director of Pitt’s Homewood Community Engagement Center, "
+                "sees himself as the ultimate connector.",
+                url="https://www.pitt.edu/pittwire/pittmagazine/features-articles/vernard-alexander-community-engagement",
+                tags=["University News", "Community Impact"],
+            ),
+        )
+        self.assertEqual(
+            university_news_articles[-1],
+            news.Article(
+                title="Pitt has 2 new Goldwater Scholars",
+                description="The prestigious scholarship is awarded to sophomores and juniors who plan to pursue "
+                "research careers in the sciences and engineering fields. Meet our winners.",
+                url="https://www.pitt.edu/pittwire/features-articles/goldwater-scholars-2024",
+                tags=[
+                    "University News",
+                    "Technology & Science",
+                    "David C. Frederick Honors College",
+                    "Kenneth P. Dietrich School of Arts and Sciences",
+                ],
+            ),
+        )

--- a/tests/samples/news_university_news_features_articles_2020.html
+++ b/tests/samples/news_university_news_features_articles_2020.html
@@ -1,0 +1,1241 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr" prefix="content: http://purl.org/rss/1.0/modules/content/  dc: http://purl.org/dc/terms/  foaf: http://xmlns.com/foaf/0.1/  og: http://ogp.me/ns#  rdfs: http://www.w3.org/2000/01/rdf-schema#  schema: http://schema.org/  sioc: http://rdfs.org/sioc/ns#  sioct: http://rdfs.org/sioc/types#  skos: http://www.w3.org/2004/02/skos/core#  xsd: http://www.w3.org/2001/XMLSchema# ">
+  <head>
+    <meta charset="utf-8" /><script type="text/javascript">(window.NREUM||(NREUM={})).init={privacy:{cookies_enabled:true},ajax:{deny_list:["bam.nr-data.net"]}};(window.NREUM||(NREUM={})).loader_config={licenseKey:"NRJS-32db2f37a7e1f41235a",applicationID:"1009016335"};;/*! For license information please see nr-loader-rum-1.264.0.min.js.LICENSE.txt */
+(()=>{var e,t,r={2983:(e,t,r)=>{"use strict";r.d(t,{D0:()=>m,gD:()=>y,Vp:()=>s,fr:()=>S,jD:()=>I,hR:()=>E,xN:()=>b,x1:()=>c,aN:()=>R,V:()=>j});var n=r(384),i=r(7864);const o={beacon:n.NT.beacon,errorBeacon:n.NT.errorBeacon,licenseKey:void 0,applicationID:void 0,sa:void 0,queueTime:void 0,applicationTime:void 0,ttGuid:void 0,user:void 0,account:void 0,product:void 0,extra:void 0,jsAttributes:{},userAttributes:void 0,atts:void 0,transactionName:void 0,tNamePlain:void 0},a={};function s(e){if(!e)throw new Error("All info objects require an agent identifier!");if(!a[e])throw new Error("Info for ".concat(e," was never set"));return a[e]}function c(e,t){if(!e)throw new Error("All info objects require an agent identifier!");a[e]=(0,i.a)(t,o);const r=(0,n.nY)(e);r&&(r.info=a[e])}var u=r(993);const l=e=>{if(!e||"string"!=typeof e)return!1;try{document.createDocumentFragment().querySelector(e)}catch{return!1}return!0};var d=r(2614),g=r(944);const f="[data-nr-mask]",h=()=>{const e={mask_selector:"*",block_selector:"[data-nr-block]",mask_input_options:{color:!1,date:!1,"datetime-local":!1,email:!1,month:!1,number:!1,range:!1,search:!1,tel:!1,text:!1,time:!1,url:!1,week:!1,textarea:!1,select:!1,password:!0}};return{ajax:{deny_list:void 0,block_internal:!0,enabled:!0,harvestTimeSeconds:10,autoStart:!0},distributed_tracing:{enabled:void 0,exclude_newrelic_header:void 0,cors_use_newrelic_header:void 0,cors_use_tracecontext_headers:void 0,allowed_origins:void 0},feature_flags:[],generic_events:{enabled:!0,harvestTimeSeconds:30,autoStart:!0},harvest:{tooManyRequestsDelay:60},jserrors:{enabled:!0,harvestTimeSeconds:10,autoStart:!0},logging:{enabled:!0,harvestTimeSeconds:10,autoStart:!0,level:u.p_.INFO},metrics:{enabled:!0,autoStart:!0},obfuscate:void 0,page_action:{enabled:!0},page_view_event:{enabled:!0,autoStart:!0},page_view_timing:{enabled:!0,harvestTimeSeconds:30,long_task:!1,autoStart:!0},privacy:{cookies_enabled:!0},proxy:{assets:void 0,beacon:void 0},session:{expiresMs:d.wk,inactiveMs:d.BB},session_replay:{autoStart:!0,enabled:!1,harvestTimeSeconds:60,preload:!1,sampling_rate:10,error_sampling_rate:100,collect_fonts:!1,inline_images:!1,inline_stylesheet:!0,fix_stylesheets:!0,mask_all_inputs:!0,get mask_text_selector(){return e.mask_selector},set mask_text_selector(t){l(t)?e.mask_selector="".concat(t,",").concat(f):""===t||null===t?e.mask_selector=f:(0,g.R)(5,t)},get block_class(){return"nr-block"},get ignore_class(){return"nr-ignore"},get mask_text_class(){return"nr-mask"},get block_selector(){return e.block_selector},set block_selector(t){l(t)?e.block_selector+=",".concat(t):""!==t&&(0,g.R)(6,t)},get mask_input_options(){return e.mask_input_options},set mask_input_options(t){t&&"object"==typeof t?e.mask_input_options={...t,password:!0}:(0,g.R)(7,t)}},session_trace:{enabled:!0,harvestTimeSeconds:10,autoStart:!0},soft_navigations:{enabled:!0,harvestTimeSeconds:10,autoStart:!0},spa:{enabled:!0,harvestTimeSeconds:10,autoStart:!0},ssl:void 0}},p={},v="All configuration objects require an agent identifier!";function m(e){if(!e)throw new Error(v);if(!p[e])throw new Error("Configuration for ".concat(e," was never set"));return p[e]}function b(e,t){if(!e)throw new Error(v);p[e]=(0,i.a)(t,h());const r=(0,n.nY)(e);r&&(r.init=p[e])}function y(e,t){if(!e)throw new Error(v);var r=m(e);if(r){for(var n=t.split("."),i=0;i<n.length-1;i++)if("object"!=typeof(r=r[n[i]]))return;r=r[n[n.length-1]]}return r}const w={accountID:void 0,trustKey:void 0,agentID:void 0,licenseKey:void 0,applicationID:void 0,xpid:void 0},A={};function R(e,t){if(!e)throw new Error("All loader-config objects require an agent identifier!");A[e]=(0,i.a)(t,w);const r=(0,n.nY)(e);r&&(r.loader_config=A[e])}const E=(0,n.dV)().o;var x=r(6154),_=r(9324);const N={buildEnv:_.F3,distMethod:_.Xs,version:_.xv,originTime:x.WN},T={customTransaction:void 0,disabled:!1,isolatedBacklog:!1,loaderType:void 0,maxBytes:3e4,onerror:void 0,origin:""+x.gm.location,ptid:void 0,releaseIds:{},appMetadata:{},session:void 0,denyList:void 0,harvestCount:0,timeKeeper:void 0},k={};function S(e){if(!e)throw new Error("All runtime objects require an agent identifier!");if(!k[e])throw new Error("Runtime for ".concat(e," was never set"));return k[e]}function j(e,t){if(!e)throw new Error("All runtime objects require an agent identifier!");k[e]={...(0,i.a)(t,T),...N};const r=(0,n.nY)(e);r&&(r.runtime=k[e])}function I(e){return function(e){try{const t=s(e);return!!t.licenseKey&&!!t.errorBeacon&&!!t.applicationID}catch(e){return!1}}(e)}},7864:(e,t,r)=>{"use strict";r.d(t,{a:()=>i});var n=r(944);function i(e,t){try{if(!e||"object"!=typeof e)return(0,n.R)(3);if(!t||"object"!=typeof t)return(0,n.R)(4);const r=Object.create(Object.getPrototypeOf(t),Object.getOwnPropertyDescriptors(t)),o=0===Object.keys(r).length?e:r;for(let a in o)if(void 0!==e[a])try{if(null===e[a]){r[a]=null;continue}Array.isArray(e[a])&&Array.isArray(t[a])?r[a]=Array.from(new Set([...e[a],...t[a]])):"object"==typeof e[a]&&"object"==typeof t[a]?r[a]=i(e[a],t[a]):r[a]=e[a]}catch(e){(0,n.R)(1,e)}return r}catch(e){(0,n.R)(2,e)}}},9324:(e,t,r)=>{"use strict";r.d(t,{F3:()=>i,Xs:()=>o,xv:()=>n});const n="1.264.0",i="PROD",o="CDN"},6154:(e,t,r)=>{"use strict";r.d(t,{OF:()=>c,RI:()=>i,Vr:()=>l,WN:()=>d,bv:()=>o,gm:()=>a,mw:()=>s,sb:()=>u});var n=r(1863);const i="undefined"!=typeof window&&!!window.document,o="undefined"!=typeof WorkerGlobalScope&&("undefined"!=typeof self&&self instanceof WorkerGlobalScope&&self.navigator instanceof WorkerNavigator||"undefined"!=typeof globalThis&&globalThis instanceof WorkerGlobalScope&&globalThis.navigator instanceof WorkerNavigator),a=i?window:"undefined"!=typeof WorkerGlobalScope&&("undefined"!=typeof self&&self instanceof WorkerGlobalScope&&self||"undefined"!=typeof globalThis&&globalThis instanceof WorkerGlobalScope&&globalThis),s=Boolean("hidden"===a?.document?.visibilityState),c=/iPad|iPhone|iPod/.test(a.navigator?.userAgent),u=c&&"undefined"==typeof SharedWorker,l=((()=>{const e=a.navigator?.userAgent?.match(/Firefox[/\s](\d+\.\d+)/);Array.isArray(e)&&e.length>=2&&e[1]})(),!!a.navigator?.sendBeacon),d=Date.now()-(0,n.t)()},4777:(e,t,r)=>{"use strict";r.d(t,{J:()=>o});var n=r(944);const i={agentIdentifier:"",ee:void 0};class o{constructor(e){try{if("object"!=typeof e)return(0,n.R)(8);this.sharedContext={},Object.assign(this.sharedContext,i),Object.entries(e).forEach((e=>{let[t,r]=e;Object.keys(i).includes(t)&&(this.sharedContext[t]=r)}))}catch(e){(0,n.R)(9,e)}}}},1687:(e,t,r)=>{"use strict";r.d(t,{Ak:()=>s,Ze:()=>l,x3:()=>c});var n=r(7836),i=r(3606),o=r(860);const a={};function s(e,t){const r={staged:!1,priority:o.P[t]||0};u(e),a[e].get(t)||a[e].set(t,r)}function c(e,t){e&&a[e]&&(a[e].get(t)&&a[e].delete(t),g(e,t,!1),a[e].size&&d(e))}function u(e){if(!e)throw new Error("agentIdentifier required");a[e]||(a[e]=new Map)}function l(){let e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:"",t=arguments.length>1&&void 0!==arguments[1]?arguments[1]:"feature",r=arguments.length>2&&void 0!==arguments[2]&&arguments[2];if(u(e),!e||!a[e].get(t)||r)return g(e,t);a[e].get(t).staged=!0,d(e)}function d(e){const t=Array.from(a[e]);t.every((e=>{let[t,r]=e;return r.staged}))&&(t.sort(((e,t)=>e[1].priority-t[1].priority)),t.forEach((t=>{let[r]=t;a[e].delete(r),g(e,r)})))}function g(e,t){let r=!(arguments.length>2&&void 0!==arguments[2])||arguments[2];const o=e?n.ee.get(e):n.ee,a=i.i.handlers;if(!o.aborted&&o.backlog&&a){if(r){const e=o.backlog[t],r=a[t];if(r){for(let t=0;e&&t<e.length;++t)f(e[t],r);Object.entries(r).forEach((e=>{let[t,r]=e;Object.values(r||{}).forEach((e=>{e[0].on(t,e[1])}))}))}}o.isolatedBacklog||delete a[t],o.backlog[t]=null,o.emit("drain-"+t,[])}}function f(e,t){var r=e[1];Object.values(t[r]||{}).forEach((t=>{var r=e[0];if(t[0]===r){var n=t[1],i=e[3],o=e[2];n.apply(i,o)}}))}},7836:(e,t,r)=>{"use strict";r.d(t,{P:()=>c,ee:()=>u});var n=r(384),i=r(8990),o=r(2983),a=r(2646),s=r(5607);const c="nr@context:".concat(s.W),u=function e(t,r){var n={},s={},l={},d=!1;try{d=16===r.length&&(0,o.fr)(r).isolatedBacklog}catch(e){}var g={on:h,addEventListener:h,removeEventListener:function(e,t){var r=n[e];if(!r)return;for(var i=0;i<r.length;i++)r[i]===t&&r.splice(i,1)},emit:function(e,r,n,i,o){!1!==o&&(o=!0);if(u.aborted&&!i)return;t&&o&&t.emit(e,r,n);for(var a=f(n),c=p(e),l=c.length,d=0;d<l;d++)c[d].apply(a,r);var h=m()[s[e]];h&&h.push([g,e,r,a]);return a},get:v,listeners:p,context:f,buffer:function(e,t){const r=m();if(t=t||"feature",g.aborted)return;Object.entries(e||{}).forEach((e=>{let[n,i]=e;s[i]=t,t in r||(r[t]=[])}))},abort:function(){g._aborted=!0,Object.keys(g.backlog).forEach((e=>{delete g.backlog[e]}))},isBuffering:function(e){return!!m()[s[e]]},debugId:r,backlog:d?{}:t&&"object"==typeof t.backlog?t.backlog:{},isolatedBacklog:d};return Object.defineProperty(g,"aborted",{get:()=>{let e=g._aborted||!1;return e||(t&&(e=t.aborted),e)}}),g;function f(e){return e&&e instanceof a.y?e:e?(0,i.I)(e,c,(()=>new a.y(c))):new a.y(c)}function h(e,t){n[e]=p(e).concat(t)}function p(e){return n[e]||[]}function v(t){return l[t]=l[t]||e(g,t)}function m(){return g.backlog}}(void 0,"globalEE"),l=(0,n.Zm)();l.ee||(l.ee=u)},2646:(e,t,r)=>{"use strict";r.d(t,{y:()=>n});class n{constructor(e){this.contextId=e}}},9908:(e,t,r)=>{"use strict";r.d(t,{d:()=>n,p:()=>i});var n=r(7836).ee.get("handle");function i(e,t,r,i,o){o?(o.buffer([e],i),o.emit(e,t,r)):(n.buffer([e],i),n.emit(e,t,r))}},3606:(e,t,r)=>{"use strict";r.d(t,{i:()=>o});var n=r(9908);o.on=a;var i=o.handlers={};function o(e,t,r,o){a(o||n.d,i,e,t,r)}function a(e,t,r,i,o){o||(o="feature"),e||(e=n.d);var a=t[o]=t[o]||{};(a[r]=a[r]||[]).push([e,i])}},3878:(e,t,r)=>{"use strict";r.d(t,{DD:()=>c,jT:()=>a,sp:()=>s});var n=r(6154);let i=!1,o=!1;try{const e={get passive(){return i=!0,!1},get signal(){return o=!0,!1}};n.gm.addEventListener("test",null,e),n.gm.removeEventListener("test",null,e)}catch(e){}function a(e,t){return i||o?{capture:!!e,passive:i,signal:t}:!!e}function s(e,t){let r=arguments.length>2&&void 0!==arguments[2]&&arguments[2],n=arguments.length>3?arguments[3]:void 0;window.addEventListener(e,t,a(r,n))}function c(e,t){let r=arguments.length>2&&void 0!==arguments[2]&&arguments[2],n=arguments.length>3?arguments[3]:void 0;document.addEventListener(e,t,a(r,n))}},5607:(e,t,r)=>{"use strict";r.d(t,{W:()=>n});const n=(0,r(9566).bz)()},9566:(e,t,r)=>{"use strict";r.d(t,{LA:()=>s,bz:()=>a});var n=r(6154);const i="xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx";function o(e,t){return e?15&e[t]:16*Math.random()|0}function a(){const e=n.gm?.crypto||n.gm?.msCrypto;let t,r=0;return e&&e.getRandomValues&&(t=e.getRandomValues(new Uint8Array(30))),i.split("").map((e=>"x"===e?o(t,r++).toString(16):"y"===e?(3&o()|8).toString(16):e)).join("")}function s(e){const t=n.gm?.crypto||n.gm?.msCrypto;let r,i=0;t&&t.getRandomValues&&(r=t.getRandomValues(new Uint8Array(e)));const a=[];for(var s=0;s<e;s++)a.push(o(r,i++).toString(16));return a.join("")}},2614:(e,t,r)=>{"use strict";r.d(t,{BB:()=>a,H3:()=>n,g:()=>u,iL:()=>c,tS:()=>s,uh:()=>i,wk:()=>o});const n="NRBA",i="SESSION",o=144e5,a=18e5,s={STARTED:"session-started",PAUSE:"session-pause",RESET:"session-reset",RESUME:"session-resume",UPDATE:"session-update"},c={SAME_TAB:"same-tab",CROSS_TAB:"cross-tab"},u={OFF:0,FULL:1,ERROR:2}},1863:(e,t,r)=>{"use strict";function n(){return Math.floor(performance.now())}r.d(t,{t:()=>n})},944:(e,t,r)=>{"use strict";function n(e,t){"function"==typeof console.debug&&console.debug("New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/docs/warning-codes.md#".concat(e),t)}r.d(t,{R:()=>n})},5284:(e,t,r)=>{"use strict";r.d(t,{t:()=>c,B:()=>s});var n=r(7836),i=r(6154);const o="newrelic";const a=new Set,s={};function c(e,t){const r=n.ee.get(t);s[t]??={},e&&"object"==typeof e&&(a.has(t)||(r.emit("rumresp",[e]),s[t]=e,a.add(t),function(){let e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:{};try{i.gm.dispatchEvent(new CustomEvent(o,{detail:e}))}catch(e){}}({loaded:!0})))}},8990:(e,t,r)=>{"use strict";r.d(t,{I:()=>i});var n=Object.prototype.hasOwnProperty;function i(e,t,r){if(n.call(e,t))return e[t];var i=r();if(Object.defineProperty&&Object.keys)try{return Object.defineProperty(e,t,{value:i,writable:!0,enumerable:!1}),i}catch(e){}return e[t]=i,i}},6389:(e,t,r)=>{"use strict";function n(e){var t=this;let r=arguments.length>1&&void 0!==arguments[1]?arguments[1]:500,n=arguments.length>2&&void 0!==arguments[2]?arguments[2]:{};const i=n?.leading||!1;let o;return function(){for(var n=arguments.length,a=new Array(n),s=0;s<n;s++)a[s]=arguments[s];i&&void 0===o&&(e.apply(t,a),o=setTimeout((()=>{o=clearTimeout(o)}),r)),i||(clearTimeout(o),o=setTimeout((()=>{e.apply(t,a)}),r))}}function i(e){var t=this;let r=!1;return function(){if(!r){r=!0;for(var n=arguments.length,i=new Array(n),o=0;o<n;o++)i[o]=arguments[o];e.apply(t,i)}}}r.d(t,{J:()=>i,s:()=>n})},5289:(e,t,r)=>{"use strict";r.d(t,{GG:()=>o,sB:()=>a});var n=r(3878);function i(){return"undefined"==typeof document||"complete"===document.readyState}function o(e,t){if(i())return e();(0,n.sp)("load",e,t)}function a(e){if(i())return e();(0,n.DD)("DOMContentLoaded",e)}},384:(e,t,r)=>{"use strict";r.d(t,{NT:()=>o,US:()=>l,Zm:()=>a,bQ:()=>c,dV:()=>s,nY:()=>u,pV:()=>d});var n=r(6154),i=r(1863);const o={beacon:"bam.nr-data.net",errorBeacon:"bam.nr-data.net"};function a(){return n.gm.NREUM||(n.gm.NREUM={}),void 0===n.gm.newrelic&&(n.gm.newrelic=n.gm.NREUM),n.gm.NREUM}function s(){let e=a();return e.o||(e.o={ST:n.gm.setTimeout,SI:n.gm.setImmediate,CT:n.gm.clearTimeout,XHR:n.gm.XMLHttpRequest,REQ:n.gm.Request,EV:n.gm.Event,PR:n.gm.Promise,MO:n.gm.MutationObserver,FETCH:n.gm.fetch}),e}function c(e,t){let r=a();r.initializedAgents??={},t.initializedAt={ms:(0,i.t)(),date:new Date},r.initializedAgents[e]=t}function u(e){let t=a();return t.initializedAgents?.[e]}function l(e,t){a()[e]=t}function d(){return function(){let e=a();const t=e.info||{};e.info={beacon:o.beacon,errorBeacon:o.errorBeacon,...t}}(),function(){let e=a();const t=e.init||{};e.init={...t}}(),s(),function(){let e=a();const t=e.loader_config||{};e.loader_config={...t}}(),a()}},2843:(e,t,r)=>{"use strict";r.d(t,{u:()=>i});var n=r(3878);function i(e){let t=arguments.length>1&&void 0!==arguments[1]&&arguments[1],r=arguments.length>2?arguments[2]:void 0,i=arguments.length>3?arguments[3]:void 0;(0,n.DD)("visibilitychange",(function(){if(t)return void("hidden"===document.visibilityState&&e());e(document.visibilityState)}),r,i)}},3434:(e,t,r)=>{"use strict";r.d(t,{YM:()=>c});var n=r(7836),i=r(5607);const o="nr@original:".concat(i.W);var a=Object.prototype.hasOwnProperty,s=!1;function c(e,t){return e||(e=n.ee),r.inPlace=function(e,t,n,i,o){n||(n="");const a="-"===n.charAt(0);for(let s=0;s<t.length;s++){const c=t[s],u=e[c];l(u)||(e[c]=r(u,a?c+n:n,i,c,o))}},r.flag=o,r;function r(t,r,n,s,c){return l(t)?t:(r||(r=""),nrWrapper[o]=t,function(e,t,r){if(Object.defineProperty&&Object.keys)try{return Object.keys(e).forEach((function(r){Object.defineProperty(t,r,{get:function(){return e[r]},set:function(t){return e[r]=t,t}})})),t}catch(e){u([e],r)}for(var n in e)a.call(e,n)&&(t[n]=e[n])}(t,nrWrapper,e),nrWrapper);function nrWrapper(){var o,a,l,d;try{a=this,o=[...arguments],l="function"==typeof n?n(o,a):n||{}}catch(t){u([t,"",[o,a,s],l],e)}i(r+"start",[o,a,s],l,c);try{return d=t.apply(a,o)}catch(e){throw i(r+"err",[o,a,e],l,c),e}finally{i(r+"end",[o,a,d],l,c)}}}function i(r,n,i,o){if(!s||t){var a=s;s=!0;try{e.emit(r,n,i,t,o)}catch(t){u([t,r,n,i],e)}s=a}}}function u(e,t){t||(t=n.ee);try{t.emit("internal-error",e)}catch(e){}}function l(e){return!(e&&"function"==typeof e&&e.apply&&!e[o])}},993:(e,t,r)=>{"use strict";r.d(t,{ET:()=>o,p_:()=>i});var n=r(860);const i={ERROR:"ERROR",WARN:"WARN",INFO:"INFO",DEBUG:"DEBUG",TRACE:"TRACE"},o="log";n.K.logging},3969:(e,t,r)=>{"use strict";r.d(t,{TZ:()=>n,XG:()=>s,rs:()=>i,xV:()=>a,z_:()=>o});const n=r(860).K.metrics,i="sm",o="cm",a="storeSupportabilityMetrics",s="storeEventMetrics"},6630:(e,t,r)=>{"use strict";r.d(t,{T:()=>n});const n=r(860).K.pageViewEvent},782:(e,t,r)=>{"use strict";r.d(t,{T:()=>n});const n=r(860).K.pageViewTiming},6344:(e,t,r)=>{"use strict";r.d(t,{G4:()=>i});var n=r(2614);r(860).K.sessionReplay;const i={RECORD:"recordReplay",PAUSE:"pauseReplay",REPLAY_RUNNING:"replayRunning",ERROR_DURING_REPLAY:"errorDuringReplay"};n.g.ERROR,n.g.FULL,n.g.OFF},4234:(e,t,r)=>{"use strict";r.d(t,{W:()=>i});var n=r(7836);class i{constructor(e,t,r){this.agentIdentifier=e,this.aggregator=t,this.ee=n.ee.get(e),this.featureName=r,this.blocked=!1}}},2266:(e,t,r)=>{"use strict";r.d(t,{j:()=>k});var n=r(860),i=r(2983),o=r(9908),a=r(7836),s=r(1687),c=r(5289),u=r(6154),l=r(944),d=r(3969),g=r(384),f=r(6344);const h=["setErrorHandler","finished","addToTrace","addRelease","addPageAction","setCurrentRouteName","setPageViewName","setCustomAttribute","interaction","noticeError","setUserId","setApplicationVersion","start",f.G4.RECORD,f.G4.PAUSE,"log","wrapLogger"],p=["setErrorHandler","finished","addToTrace","addRelease"];var v=r(1863),m=r(2614),b=r(993);var y=r(2646),w=r(3434);function A(e,t,r,n){if("object"!=typeof t||!t||"string"!=typeof r||!r||"function"!=typeof t[r])return(0,l.R)(29);const i=function(e){return(e||a.ee).get("logger")}(e),o=(0,w.YM)(i),s=new y.y(a.P);return s.level=n.level,s.customAttributes=n.customAttributes,o.inPlace(t,[r],"wrap-logger-",s),i}function R(){const e=(0,g.pV)();h.forEach((t=>{e[t]=function(){for(var r=arguments.length,n=new Array(r),i=0;i<r;i++)n[i]=arguments[i];return function(t){for(var r=arguments.length,n=new Array(r>1?r-1:0),i=1;i<r;i++)n[i-1]=arguments[i];let o=[];return Object.values(e.initializedAgents).forEach((e=>{e&&e.api?e.exposed&&e.api[t]&&o.push(e.api[t](...n)):(0,l.R)(38,t)})),o.length>1?o:o[0]}(t,...n)}}))}const E={};function x(e,t){let g=arguments.length>2&&void 0!==arguments[2]&&arguments[2];t||(0,s.Ak)(e,"api");const h={};var y=a.ee.get(e),w=y.get("tracer");E[e]=m.g.OFF,y.on(f.G4.REPLAY_RUNNING,(t=>{E[e]=t}));var R="api-",x=R+"ixn-";function _(t,r,n,o){const a=(0,i.Vp)(e);return null===r?delete a.jsAttributes[t]:(0,i.x1)(e,{...a,jsAttributes:{...a.jsAttributes,[t]:r}}),k(R,n,!0,o||null===r?"session":void 0)(t,r)}function N(){}h.log=function(e){let{customAttributes:t={},level:r=b.p_.INFO}=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{};(0,o.p)(d.xV,["API/log/called"],void 0,n.K.metrics,y),function(e,t){let r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:{},i=arguments.length>3&&void 0!==arguments[3]?arguments[3]:b.p_.INFO;(0,o.p)(d.xV,["API/logging/".concat(i.toLowerCase(),"/called")],void 0,n.K.metrics,e),(0,o.p)(b.ET,[(0,v.t)(),t,r,i],void 0,n.K.logging,e)}(y,e,t,r)},h.wrapLogger=function(e,t){let{customAttributes:r={},level:i=b.p_.INFO}=arguments.length>2&&void 0!==arguments[2]?arguments[2]:{};(0,o.p)(d.xV,["API/wrapLogger/called"],void 0,n.K.metrics,y),A(y,e,t,{customAttributes:r,level:i})},p.forEach((e=>{h[e]=k(R,e,!0,"api")})),h.addPageAction=k(R,"addPageAction",!0,n.K.genericEvents),h.setPageViewName=function(t,r){if("string"==typeof t)return"/"!==t.charAt(0)&&(t="/"+t),(0,i.fr)(e).customTransaction=(r||"http://custom.transaction")+t,k(R,"setPageViewName",!0)()},h.setCustomAttribute=function(e,t){let r=arguments.length>2&&void 0!==arguments[2]&&arguments[2];if("string"==typeof e){if(["string","number","boolean"].includes(typeof t)||null===t)return _(e,t,"setCustomAttribute",r);(0,l.R)(40,typeof t)}else(0,l.R)(39,typeof e)},h.setUserId=function(e){if("string"==typeof e||null===e)return _("enduser.id",e,"setUserId",!0);(0,l.R)(41,typeof e)},h.setApplicationVersion=function(e){if("string"==typeof e||null===e)return _("application.version",e,"setApplicationVersion",!1);(0,l.R)(42,typeof e)},h.start=()=>{try{(0,o.p)(d.xV,["API/start/called"],void 0,n.K.metrics,y),y.emit("manual-start-all")}catch(e){(0,l.R)(23,e)}},h[f.G4.RECORD]=function(){(0,o.p)(d.xV,["API/recordReplay/called"],void 0,n.K.metrics,y),(0,o.p)(f.G4.RECORD,[],void 0,n.K.sessionReplay,y)},h[f.G4.PAUSE]=function(){(0,o.p)(d.xV,["API/pauseReplay/called"],void 0,n.K.metrics,y),(0,o.p)(f.G4.PAUSE,[],void 0,n.K.sessionReplay,y)},h.interaction=function(e){return(new N).get("object"==typeof e?e:{})};const T=N.prototype={createTracer:function(e,t){var r={},i=this,a="function"==typeof t;return(0,o.p)(d.xV,["API/createTracer/called"],void 0,n.K.metrics,y),g||(0,o.p)(x+"tracer",[(0,v.t)(),e,r],i,n.K.spa,y),function(){if(w.emit((a?"":"no-")+"fn-start",[(0,v.t)(),i,a],r),a)try{return t.apply(this,arguments)}catch(e){const t="string"==typeof e?new Error(e):e;throw w.emit("fn-err",[arguments,this,t],r),t}finally{w.emit("fn-end",[(0,v.t)()],r)}}}};function k(e,t,r,i){return function(){return(0,o.p)(d.xV,["API/"+t+"/called"],void 0,n.K.metrics,y),i&&(0,o.p)(e+t,[(0,v.t)(),...arguments],r?null:this,i,y),r?void 0:this}}function S(){r.e(296).then(r.bind(r,8778)).then((t=>{let{setAPI:r}=t;r(e),(0,s.Ze)(e,"api")})).catch((e=>{(0,l.R)(27,e),y.abort()}))}return["actionText","setName","setAttribute","save","ignore","onEnd","getContext","end","get"].forEach((e=>{T[e]=k(x,e,void 0,g?n.K.softNav:n.K.spa)})),h.setCurrentRouteName=g?k(x,"routeName",void 0,n.K.softNav):k(R,"routeName",!0,n.K.spa),h.noticeError=function(t,r){"string"==typeof t&&(t=new Error(t)),(0,o.p)(d.xV,["API/noticeError/called"],void 0,n.K.metrics,y),(0,o.p)("err",[t,(0,v.t)(),!1,r,!!E[e]],void 0,n.K.jserrors,y)},u.RI?(0,c.GG)((()=>S()),!0):S(),h}var _=r(5284);const N=e=>{const t=e.startsWith("http");e+="/",r.p=t?e:"https://"+e};let T=!1;function k(e){let t=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{},r=arguments.length>2?arguments[2]:void 0,n=arguments.length>3?arguments[3]:void 0,{init:o,info:s,loader_config:c,runtime:l={},exposed:d=!0}=t;l.loaderType=r;const f=(0,g.pV)();s||(o=f.init,s=f.info,c=f.loader_config),(0,i.xN)(e.agentIdentifier,o||{}),(0,i.aN)(e.agentIdentifier,c||{}),s.jsAttributes??={},u.bv&&(s.jsAttributes.isWorker=!0),(0,i.x1)(e.agentIdentifier,s);const h=(0,i.D0)(e.agentIdentifier),p=[s.beacon,s.errorBeacon];T||(h.proxy.assets&&(N(h.proxy.assets),p.push(h.proxy.assets)),h.proxy.beacon&&p.push(h.proxy.beacon),R(),(0,g.US)("activatedFeatures",_.B),e.runSoftNavOverSpa&&=!0===h.soft_navigations.enabled&&h.feature_flags.includes("soft_nav")),l.denyList=[...h.ajax.deny_list||[],...h.ajax.block_internal?p:[]],l.ptid=e.agentIdentifier,(0,i.V)(e.agentIdentifier,l),e.ee=a.ee.get(e.agentIdentifier),void 0===e.api&&(e.api=x(e.agentIdentifier,n,e.runSoftNavOverSpa)),void 0===e.exposed&&(e.exposed=d),T=!0}},8374:(e,t,r)=>{r.nc=(()=>{try{return document?.currentScript?.nonce}catch(e){}return""})()},860:(e,t,r)=>{"use strict";r.d(t,{K:()=>n,P:()=>i});const n={ajax:"ajax",genericEvents:"generic_events",jserrors:"jserrors",logging:"logging",metrics:"metrics",pageAction:"page_action",pageViewEvent:"page_view_event",pageViewTiming:"page_view_timing",sessionReplay:"session_replay",sessionTrace:"session_trace",softNav:"soft_navigations",spa:"spa"},i={[n.pageViewEvent]:1,[n.pageViewTiming]:2,[n.metrics]:3,[n.jserrors]:4,[n.spa]:5,[n.ajax]:6,[n.sessionTrace]:7,[n.softNav]:8,[n.sessionReplay]:9,[n.logging]:10,[n.genericEvents]:11}}},n={};function i(e){var t=n[e];if(void 0!==t)return t.exports;var o=n[e]={exports:{}};return r[e](o,o.exports,i),o.exports}i.m=r,i.d=(e,t)=>{for(var r in t)i.o(t,r)&&!i.o(e,r)&&Object.defineProperty(e,r,{enumerable:!0,get:t[r]})},i.f={},i.e=e=>Promise.all(Object.keys(i.f).reduce(((t,r)=>(i.f[r](e,t),t)),[])),i.u=e=>"nr-rum-1.264.0.min.js",i.o=(e,t)=>Object.prototype.hasOwnProperty.call(e,t),e={},t="NRBA-1.264.0.PROD:",i.l=(r,n,o,a)=>{if(e[r])e[r].push(n);else{var s,c;if(void 0!==o)for(var u=document.getElementsByTagName("script"),l=0;l<u.length;l++){var d=u[l];if(d.getAttribute("src")==r||d.getAttribute("data-webpack")==t+o){s=d;break}}if(!s){c=!0;var g={296:"sha512-/JFTCbNPZPe6tX1oowGTDXgTXJPZczBrsUMXw4/4Iz7c/U06sSfloejUIdps4/XHjV4Xx4uaRdele2Dq0BHQlw=="};(s=document.createElement("script")).charset="utf-8",s.timeout=120,i.nc&&s.setAttribute("nonce",i.nc),s.setAttribute("data-webpack",t+o),s.src=r,0!==s.src.indexOf(window.location.origin+"/")&&(s.crossOrigin="anonymous"),g[a]&&(s.integrity=g[a])}e[r]=[n];var f=(t,n)=>{s.onerror=s.onload=null,clearTimeout(h);var i=e[r];if(delete e[r],s.parentNode&&s.parentNode.removeChild(s),i&&i.forEach((e=>e(n))),t)return t(n)},h=setTimeout(f.bind(null,void 0,{type:"timeout",target:s}),12e4);s.onerror=f.bind(null,s.onerror),s.onload=f.bind(null,s.onload),c&&document.head.appendChild(s)}},i.r=e=>{"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(e,"__esModule",{value:!0})},i.p="https://js-agent.newrelic.com/",(()=>{var e={840:0,374:0};i.f.j=(t,r)=>{var n=i.o(e,t)?e[t]:void 0;if(0!==n)if(n)r.push(n[2]);else{var o=new Promise(((r,i)=>n=e[t]=[r,i]));r.push(n[2]=o);var a=i.p+i.u(t),s=new Error;i.l(a,(r=>{if(i.o(e,t)&&(0!==(n=e[t])&&(e[t]=void 0),n)){var o=r&&("load"===r.type?"missing":r.type),a=r&&r.target&&r.target.src;s.message="Loading chunk "+t+" failed.\n("+o+": "+a+")",s.name="ChunkLoadError",s.type=o,s.request=a,n[1](s)}}),"chunk-"+t,t)}};var t=(t,r)=>{var n,o,[a,s,c]=r,u=0;if(a.some((t=>0!==e[t]))){for(n in s)i.o(s,n)&&(i.m[n]=s[n]);if(c)c(i)}for(t&&t(r);u<a.length;u++)o=a[u],i.o(e,o)&&e[o]&&e[o][0](),e[o]=0},r=self["webpackChunk:NRBA-1.264.0.PROD"]=self["webpackChunk:NRBA-1.264.0.PROD"]||[];r.forEach(t.bind(null,0)),r.push=t.bind(null,r.push.bind(r))})(),(()=>{"use strict";i(8374);var e=i(944),t=i(6344),r=i(9566);class n{agentIdentifier;constructor(){let e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:(0,r.LA)(16);this.agentIdentifier=e}#e(t){for(var r=arguments.length,n=new Array(r>1?r-1:0),i=1;i<r;i++)n[i-1]=arguments[i];if("function"==typeof this.api?.[t])return this.api[t](...n);(0,e.R)(35,t)}addPageAction(e,t){return this.#e("addPageAction",e,t)}setPageViewName(e,t){return this.#e("setPageViewName",e,t)}setCustomAttribute(e,t,r){return this.#e("setCustomAttribute",e,t,r)}noticeError(e,t){return this.#e("noticeError",e,t)}setUserId(e){return this.#e("setUserId",e)}setApplicationVersion(e){return this.#e("setApplicationVersion",e)}setErrorHandler(e){return this.#e("setErrorHandler",e)}finished(e){return this.#e("finished",e)}addRelease(e,t){return this.#e("addRelease",e,t)}start(e){return this.#e("start",e)}recordReplay(){return this.#e(t.G4.RECORD)}pauseReplay(){return this.#e(t.G4.PAUSE)}addToTrace(e){return this.#e("addToTrace",e)}setCurrentRouteName(e){return this.#e("setCurrentRouteName",e)}interaction(){return this.#e("interaction")}log(e,t){return this.#e("logInfo",e,t)}wrapLogger(e,t,r){return this.#e("wrapLogger",e,t,r)}}var o=i(860),a=i(2983);const s=Object.values(o.K);function c(e){const t={};return s.forEach((r=>{t[r]=function(e,t){return!0===(0,a.gD)(t,"".concat(e,".enabled"))}(r,e)})),t}var u=i(2266);var l=i(1687),d=i(4234),g=i(5289),f=i(6154);const h=e=>f.RI&&!0===(0,a.gD)(e,"privacy.cookies_enabled");function p(e){return!!a.hR.MO&&h(e)&&!0===(0,a.gD)(e,"session_trace.enabled")}var v=i(6389);class m extends d.W{constructor(e,t,r){let n=!(arguments.length>3&&void 0!==arguments[3])||arguments[3];super(e,t,r),this.auto=n,this.abortHandler=void 0,this.featAggregate=void 0,this.onAggregateImported=void 0,!1===(0,a.gD)(this.agentIdentifier,"".concat(this.featureName,".autoStart"))&&(this.auto=!1),this.auto?(0,l.Ak)(e,r):this.ee.on("manual-start-all",(0,v.J)((()=>{(0,l.Ak)(this.agentIdentifier,this.featureName),this.auto=!0,this.importAggregator()})))}importAggregator(){let t,r=arguments.length>0&&void 0!==arguments[0]?arguments[0]:{};if(this.featAggregate||!this.auto)return;this.onAggregateImported=new Promise((e=>{t=e}));const n=async()=>{let n;try{if(h(this.agentIdentifier)){const{setupAgentSession:e}=await i.e(296).then(i.bind(i,2987));n=e(this.agentIdentifier)}}catch(t){(0,e.R)(20,t),this.ee.emit("internal-error",[t]),this.featureName===o.K.sessionReplay&&this.abortHandler?.()}try{if(!this.#t(this.featureName,n))return(0,l.Ze)(this.agentIdentifier,this.featureName),void t(!1);const{lazyFeatureLoader:e}=await i.e(296).then(i.bind(i,6103)),{Aggregate:o}=await e(this.featureName,"aggregate");this.featAggregate=new o(this.agentIdentifier,this.aggregator,r),t(!0)}catch(r){(0,e.R)(34,r),this.abortHandler?.(),(0,l.Ze)(this.agentIdentifier,this.featureName,!0),t(!1),this.ee&&this.ee.abort()}};f.RI?(0,g.GG)((()=>n()),!0):n()}#t(e,t){switch(e){case o.K.sessionReplay:return p(this.agentIdentifier)&&!!t;case o.K.sessionTrace:return!!t;default:return!0}}}var b=i(6630);class y extends m{static featureName=(()=>b.T)();constructor(e,t){let r=!(arguments.length>2&&void 0!==arguments[2])||arguments[2];super(e,t,b.T,r),this.importAggregator()}}var w=i(4777);class A extends w.J{constructor(e){super(e),this.aggregatedData={}}store(e,t,r,n,i){var o=this.getBucket(e,t,r,i);return o.metrics=function(e,t){t||(t={count:0});return t.count+=1,Object.entries(e||{}).forEach((e=>{let[r,n]=e;t[r]=R(n,t[r])})),t}(n,o.metrics),o}merge(e,t,r,n,i){var o=this.getBucket(e,t,n,i);if(o.metrics){var a=o.metrics;a.count+=r.count,Object.keys(r||{}).forEach((e=>{if("count"!==e){var t=a[e],n=r[e];n&&!n.c?a[e]=R(n.t,t):a[e]=function(e,t){if(!t)return e;t.c||(t=E(t.t));return t.min=Math.min(e.min,t.min),t.max=Math.max(e.max,t.max),t.t+=e.t,t.sos+=e.sos,t.c+=e.c,t}(n,a[e])}}))}else o.metrics=r}storeMetric(e,t,r,n){var i=this.getBucket(e,t,r);return i.stats=R(n,i.stats),i}getBucket(e,t,r,n){this.aggregatedData[e]||(this.aggregatedData[e]={});var i=this.aggregatedData[e][t];return i||(i=this.aggregatedData[e][t]={params:r||{}},n&&(i.custom=n)),i}get(e,t){return t?this.aggregatedData[e]&&this.aggregatedData[e][t]:this.aggregatedData[e]}take(e){for(var t={},r="",n=!1,i=0;i<e.length;i++)t[r=e[i]]=Object.values(this.aggregatedData[r]||{}),t[r].length&&(n=!0),delete this.aggregatedData[r];return n?t:null}}function R(e,t){return null==e?function(e){e?e.c++:e={c:1};return e}(t):t?(t.c||(t=E(t.t)),t.c+=1,t.t+=e,t.sos+=e*e,e>t.max&&(t.max=e),e<t.min&&(t.min=e),t):{t:e}}function E(e){return{t:e,min:e,max:e,sos:e*e,c:1}}var x=i(384);var _=i(9908),N=i(2843),T=i(3878),k=i(782),S=i(1863);class j extends m{static featureName=(()=>k.T)();constructor(e,t){let r=!(arguments.length>2&&void 0!==arguments[2])||arguments[2];super(e,t,k.T,r),f.RI&&((0,N.u)((()=>(0,_.p)("docHidden",[(0,S.t)()],void 0,k.T,this.ee)),!0),(0,T.sp)("pagehide",(()=>(0,_.p)("winPagehide",[(0,S.t)()],void 0,k.T,this.ee))),this.importAggregator())}}var I=i(3969);class O extends m{static featureName=(()=>I.TZ)();constructor(e,t){let r=!(arguments.length>2&&void 0!==arguments[2])||arguments[2];super(e,t,I.TZ,r),this.importAggregator()}}new class extends n{constructor(t,r){super(r),f.gm?(this.sharedAggregator=new A({agentIdentifier:this.agentIdentifier}),this.features={},(0,x.bQ)(this.agentIdentifier,this),this.desiredFeatures=new Set(t.features||[]),this.desiredFeatures.add(y),this.runSoftNavOverSpa=[...this.desiredFeatures].some((e=>e.featureName===o.K.softNav)),(0,u.j)(this,t,t.loaderType||"agent"),this.run()):(0,e.R)(21)}get config(){return{info:this.info,init:this.init,loader_config:this.loader_config,runtime:this.runtime}}run(){try{const t=c(this.agentIdentifier),r=[...this.desiredFeatures];r.sort(((e,t)=>o.P[e.featureName]-o.P[t.featureName])),r.forEach((r=>{if(!t[r.featureName]&&r.featureName!==o.K.pageViewEvent)return;if(this.runSoftNavOverSpa&&r.featureName===o.K.spa)return;if(!this.runSoftNavOverSpa&&r.featureName===o.K.softNav)return;(function(e){switch(e){case o.K.ajax:return[o.K.jserrors];case o.K.sessionTrace:return[o.K.ajax,o.K.pageViewEvent];case o.K.sessionReplay:return[o.K.sessionTrace];case o.K.pageViewTiming:return[o.K.pageViewEvent];default:return[]}})(r.featureName).every((e=>e in this.features))||(0,e.R)(36,r.featureName),this.features[r.featureName]=new r(this.agentIdentifier,this.sharedAggregator)}))}catch(t){(0,e.R)(22,t);for(const e in this.features)this.features[e].abortHandler?.();const r=(0,x.Zm)();delete r.initializedAgents[this.agentIdentifier]?.api,delete r.initializedAgents[this.agentIdentifier]?.features,delete this.sharedAggregator;return r.ee.get(this.agentIdentifier).abort(),!1}}}({features:[y,j,O],loaderType:"lite"})})()})();</script>
+<link rel="canonical" href="https://www.pitt.edu/pittwire/news/features-articles" />
+<meta property="og:site_name" content="University of Pittsburgh" />
+<meta property="og:type" content="website" />
+<meta property="og:url" content="https://www.pitt.edu/pittwire/news/features-articles" />
+<meta property="og:title" content="Pittwire News" />
+<meta name="MobileOptimized" content="width" />
+<meta name="HandheldFriendly" content="true" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<script type="application/ld+json">{
+    "@context": "https://schema.org",
+    "@graph": [
+        {
+            "@type": "Organization",
+            "@id": "https://www.pitt.edu/",
+            "name": "University of Pittsburgh",
+            "url": "https://www.pitt.edu/"
+        }
+    ]
+}</script>
+<link rel="icon" href="/sites/default/files/favicon.ico" type="image/vnd.microsoft.icon" />
+
+    <title>Pittwire News | University of Pittsburgh</title>
+    <link rel="stylesheet" media="all" href="/core/modules/system/css/components/ajax-progress.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/align.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/autocomplete-loading.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/fieldgroup.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/container-inline.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/clearfix.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/details.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/hidden.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/item-list.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/js.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/nowrap.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/position-container.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/progress.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/reset-appearance.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/resize.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/sticky-header.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/system-status-counter.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/system-status-report-counters.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/system-status-report-general-info.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/tabledrag.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/tablesort.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/tree-child.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/media/css/oembed.formatter.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/views/css/views.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/sites/default/files/micon/fa/style.css?shklz9" />
+<link rel="stylesheet" media="all" href="/modules/contrib/social_media_links/css/social_media_links.theme.css?shklz9" />
+<link rel="stylesheet" media="all" href="/modules/contrib/extlink/extlink.css?shklz9" />
+<link rel="stylesheet" media="all" href="/modules/contrib/paragraphs/css/paragraphs.unpublished.css?shklz9" />
+<link rel="stylesheet" media="all" href="/modules/contrib/better_exposed_filters/css/better_exposed_filters.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/global-styles.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/navigation.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/hero-banner.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/content-well.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/template-layout-mixin.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/collapse.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/footer-override.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/button.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/breadcrumb.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/cse.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/overrides.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/pittmag.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/contrib/zensource_front_end/css/components/hero-placeholder.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/contrib/zensource_front_end/css/classy/components/messages.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/contrib/zensource_front_end/css/classy/components/details.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/contrib/zenny/css/classy/components/pager.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/card.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/contrib/zensource_front_end/css/components/entity-overlay.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/media-item.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/choices.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/form.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/modal.css?shklz9" />
+
+
+	<!-- Google Tag Manager -->
+	<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+	new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+	j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+	'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+	})(window,document,'script','dataLayer','GTM-NXCGL72');</script>
+	<!-- End Google Tag Manager -->
+
+  <script async src="https://cse.google.com/cse.js?cx=013753980878518964357:mgrjnoukllc"></script>
+
+  </head>
+  <body class="path-pittwire">
+	<!-- Google Tag Manager (noscript) -->
+	<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NXCGL72"
+	height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+	<!-- End Google Tag Manager (noscript) -->
+
+        <a href="#main-content" class="visually-hidden focusable skip-link">
+      Skip to main content
+    </a>
+
+      <div class="dialog-off-canvas-main-canvas" data-off-canvas-main-canvas>
+
+
+        <div id="block-pitt-pittwire-sitebranding" class="block block-system block-system-branding-block">
+
+
+  <!-- global nav -->
+<div class="header-wrapper" role="region" aria-label="Navigation area">
+<header class="header pitt-wire">
+  <div class="header-container">
+    <div class="header-grid">
+      <div class="pitt-wire-nav">
+        <div class="logo">
+                      <div class="logo-pitt"><a href="/"><img src="/themes/custom/pitt_pittwire/logo.svg" alt="University of Pittsburgh"></a></div>
+            <div class="logo-pitt print-only"><img src="/themes/custom/pitt_pittwire/logo-print.png" alt="UPitt Logo"></div>
+                    <div class="logo-pitt-wire"><a href="/pittwire"><img src="/themes/custom/pitt_pittwire/logo-pittwire.svg" alt="Pitt Wire"></a></div>
+          <div class="logo-pitt-wire print-only"><img src="/themes/custom/pitt_pittwire/logo-pittwire-print.png" alt="Pitt Wire"></div>
+        </div>
+        <div class="explore-sections"><button class="" data-toggle="modal" data-target="#pitt-wire-menu" data-gtm="">Explore Sections</button></div>
+      </div>
+      <!-- main navigation -->
+      <div class="navigation" role="navigation" aria-label="Mega Menu">
+        <ul class="navigation-button-wrapper">
+          <li>
+            <button type="button" class="navigation-button" data-toggle="modal" data-target="#pittwire-search-menu" data-gtm="">
+              <span class="sr-only">open search</span>
+              <span class="icon-search"></span>
+            </button>
+          </li>
+          <li>
+            <button type="button" class="navigation-button" data-toggle="modal" data-target="#hamburger-menu" data-gtm="">
+              <span class="sr-only">open menu</span>
+              <span class="icon-hamburger"></span>
+            </button>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</header>
+</div>
+</div>
+
+
+<div id="pitt-wire-menu" class="modal modal--side navigation-slide-menu left pitt-wire-menu" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <!-- modal - header -->
+      <div class="modal-header">
+        <!-- modal - dismiss -->
+        <button type="button" class="modal-dismiss-button" data-dismiss="modal" aria-label="Close" data-gtm="">
+          <span class="sr-only">Close</span>
+        </button>
+      </div>
+      <!-- modal - body -->
+      <div class="modal-body">
+               	        <p class="field field--type-string-long field--label-hidden field__item">
+	  	  From the latest big breakthrough to the most influential and inspiring figures on campus to Pitt in the community, Pittwire is your official source for what’s happening now.
+	  	  </p>
+
+        <div class="hamburger-menu-wrapper">
+          <div class="hamburger-menu-upper">
+            <div id="block-pittwireexploretopics" class="hamburger-menu-upper-column block block-menu menu--pittwire-explore-topics">
+    <div class="hamburger-menu-header">Explore Sections</div>
+
+
+
+                <ul class="hamburger-menu-list">
+                    <li>
+                <a href="/pittwire/health-and-wellness" data-drupal-link-system-path="node/21">Health and Wellness</a>
+            </li>
+                    <li>
+                <a href="/pittwire/technology-and-science" data-drupal-link-system-path="node/13546">Technology and Science</a>
+            </li>
+                    <li>
+                <a href="/pittwire/arts-and-humanities" data-drupal-link-system-path="node/13547">Arts and Humanities</a>
+            </li>
+                    <li>
+                <a href="/pittwire/community-impact" data-drupal-link-system-path="node/13548">Community Impact</a>
+            </li>
+                    <li>
+                <a href="/pittwire/diversity-equity-and-inclusion" data-drupal-link-system-path="node/13551">Diversity, Equity, and Inclusion</a>
+            </li>
+                    <li>
+                <a href="/pittwire/global" data-drupal-link-system-path="node/13550">Global</a>
+            </li>
+                    <li>
+                <a href="/pittwire/innovation-and-research" data-drupal-link-system-path="node/13549">Innovation and Research</a>
+            </li>
+                    <li>
+                <a href="/pittwire/our-cityour-campus" data-drupal-link-system-path="node/13552">Our City/Our Campus</a>
+            </li>
+                    <li>
+                <a href="/pittwire/pittmagazine" data-drupal-link-system-path="pittwire/pittmagazine">Pitt Magazine</a>
+            </li>
+                </ul>
+
+
+
+    </div>
+            <div class="views-element-container hamburger-menu-upper-column block block-views block-views-blockcategory-menu-category-menu" id="block-views-block-category-menu-category-menu">
+            <div class="hamburger-menu-header">Explore By Category</div>
+                <div><div class="view view-category-menu view-id-category_menu view-display-id-category_menu js-view-dom-id-60bb327465850e99c8a9a330bbee399f6e366189162808df036d1684e039b77a">
+
+
+
+      <div class="view-content">
+      <ul class="hamburger-menu-list">
+            <li><div class="views-field views-field-name"><span class="field-content"><a href="/pittwire/news/features-articles">Features &amp; Articles</a></span></div></li>
+            <li><div class="views-field views-field-name"><span class="field-content"><a href="/pittwire/news/accolades-honors">Accolades &amp; Honors</a></span></div></li>
+            <li><div class="views-field views-field-name"><span class="field-content"><a href="/pittwire/news/ones-to-watch">Ones to Watch</a></span></div></li>
+            <li><div class="views-field views-field-name"><span class="field-content"><a href="/pittwire/news/announcements-and-updates">Announcements and Updates</a></span></div></li>
+    </ul>
+
+    </div>
+
+          </div>
+</div>
+
+
+    <nav role="navigation" aria-labelledby="block-pittwireotherlinks-menu" id="block-pittwireotherlinks" class="block block-menu navigation menu--pittwire-other-links">
+
+  <h2 class="visually-hidden" id="block-pittwireotherlinks-menu">Pittwire Other Links</h2>
+
+
+
+<ul class="hamburger-menu-main">
+            <li>
+            <a href="https://calendar.pitt.edu/" target="_blank">Event Calendar</a>
+        </li>
+            <li>
+            <a href="https://www.pitt.edu/social" target="_blank">Social Media Directory</a>
+        </li>
+    </ul>
+
+
+
+  </nav>
+
+</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="search-menu" class="modal modal--side navigation-slide-menu right" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <!-- modal - header -->
+      <div class="modal-header">
+        <!-- modal - dismiss -->
+        <button type="button" class="modal-dismiss-button" data-dismiss="modal" aria-label="Close" data-gtm="">
+          <span class="sr-only">Close</span>
+        </button>
+      </div>
+      <!-- modal - body -->
+      <div class="modal-body">
+        <div class="search-menu-wrapper">
+          <div class="search-menu-header">Search Pitt</div>
+
+          <div class="search-menu-typeahead-wrapper">
+            <div class="search-menu-typeahead">
+              <label for="main-search-nav" class="sr-only">Search</label>
+
+              <!-- cse markup -->
+              <div class="gcse-searchbox-only" data-enableHistory="true" data-autoCompleteMaxCompletions="5" data-autoCompleteMatchType="any" data-resultsUrl="search-results"></div>
+
+            </div>
+
+          </div>
+
+
+          <div class="search-menu-footer">
+            <a href="https://find.pitt.edu" class="arrow">Search for People</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<div id="hamburger-menu" class="modal modal--side navigation-slide-menu right" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <!-- modal - header -->
+      <div class="modal-header">
+        <!-- modal - dismiss -->
+        <button type="button" class="modal-dismiss-button" data-dismiss="modal" aria-label="Close" data-gtm="">
+          <span class="sr-only">Close</span>
+        </button>
+      </div>
+      <!-- modal - body -->
+      <div class="modal-body">
+        <div class="hamburger-menu-wrapper">
+                      <div id="block-hamburgermenuupper-2" class="hamburger-menu-upper block block-blockgroup block-block-grouphamburger-menu-upper">
+
+
+      <div id="block-hamburgermenuuppercolumn1" class="hamburger-menu-upper-column block block-blockgroup block-block-grouphamburger-menu-upper-column-1">
+
+
+      <nav role="navigation" aria-labelledby="block-globalmenu-3-menu" id="block-globalmenu-3" class="block block-menu navigation menu--global-menu">
+
+  <h2 class="visually-hidden" id="block-globalmenu-3-menu">Global Menu</h2>
+
+
+
+        <ul class="hamburger-menu-main">
+          <li>
+	  <a href="https://admissions.pitt.edu/apply/" class="data-gtm-utilityNavKPI" data-contentTitle="Apply">Apply</a>
+      </li>
+          <li>
+	  <a href="https://admissions.pitt.edu/visit/unscripted/" class="data-gtm-utilityNavKPI" data-contentTitle="Visit">Visit</a>
+      </li>
+          <li>
+	  <a href="https://www.giveto.pitt.edu/s/1729/18/home-giving.aspx?gid=2&amp;pgid=2135" class="data-gtm-utilityNavKPI" data-contentTitle="Give">Give</a>
+      </li>
+          <li>
+	  <a href="/pittwire" class="data-gtm-utilityNavKPI" data-contentTitle="Pittwire">Pittwire</a>
+      </li>
+          <li>
+	  <a href="http://calendar.pitt.edu/" class="data-gtm-utilityNavKPI" data-contentTitle="Events">Events</a>
+      </li>
+        </ul>
+
+
+
+  </nav>
+      <button is="menu-blockmain-btn" class="collapse-trigger--md collapsed hamburger-menu-header-btn" role="tab" data-toggle="collapse" data-target="#menu-blockmain" aria-expanded="false" aria-controls="menu-blockmain" data-gtm="">Navigation</button>
+<div class="collapse-target--md collapse" id="menu-blockmain" role="tabpanel" aria-labelledby="menu-blockmain-btn">
+
+
+  <div  id="block-navigation-2-menu" class="hamburger-menu-header">Navigation</div>
+
+
+
+        <ul class="hamburger-menu-list">
+          <li>
+		<a href="/about" class="data-gtm-utilityNavCategory" data-contentTitle="About">About</a>
+      </li>
+          <li>
+		<a href="/academics" class="data-gtm-utilityNavCategory" data-contentTitle="Academics">Academics</a>
+      </li>
+          <li>
+		<a href="/admissions" class="data-gtm-utilityNavCategory" data-contentTitle="Admissions">Admissions</a>
+      </li>
+          <li>
+		<a href="/research" class="data-gtm-utilityNavCategory" data-contentTitle="Research">Research</a>
+      </li>
+          <li>
+		<a href="/student-life" class="data-gtm-utilityNavCategory" data-contentTitle="Life at Pitt">Life at Pitt</a>
+      </li>
+          <li>
+		<a href="http://pittsburghpanthers.com/" class="data-gtm-utilityNavCategory" data-contentTitle="Athletics">Athletics</a>
+      </li>
+        </ul>
+
+
+
+  </div>
+
+  </div>
+<div id="block-hamburgermenuuppercolumn2" class="hamburger-menu-upper-column block block-blockgroup block-block-grouphamburger-menu-upper-">
+
+
+            <button is="menu-blockquick-links-3-btn" class="collapse-trigger--md collapsed hamburger-menu-header-btn" role="tab" data-toggle="collapse" data-target="#menu-blockquick-links-3" aria-expanded="false" aria-controls="menu-blockquick-links-3" data-gtm="">Colleges &amp; Schools</button>
+<div class="collapse-target--md collapse" id="menu-blockquick-links-3" role="tabpanel" aria-labelledby="menu-blockquick-links-3-btn">
+
+
+  <div  id="block-collegesschools-2-menu" class="hamburger-menu-header">Colleges &amp; Schools</div>
+
+
+
+        <ul class="hamburger-menu-list">
+          <li>
+		<a href="https://www.as.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Arts &amp; Sciences">Arts &amp; Sciences</a>
+      </li>
+          <li>
+		<a href="https://www.business.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Business">Business</a>
+      </li>
+          <li>
+		<a href="https://www.sci.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Computing &amp; Information">Computing &amp; Information</a>
+      </li>
+          <li>
+		<a href="https://www.dental.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Dental Medicine">Dental Medicine</a>
+      </li>
+          <li>
+		<a href="https://www.education.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Education">Education</a>
+      </li>
+          <li>
+		<a href="https://www.engineering.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Engineering">Engineering</a>
+      </li>
+          <li>
+		<a href="https://www.cgs.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="General Studies">General Studies</a>
+      </li>
+          <li>
+		<a href="https://www.shrs.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Health &amp; Rehabilitation">Health &amp; Rehabilitation</a>
+      </li>
+          <li>
+		<a href="https://www.honors.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Honors College">Honors College</a>
+      </li>
+          <li>
+		<a href="https://www.law.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Law">Law</a>
+      </li>
+          <li>
+		<a href="https://www.medschool.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Medicine">Medicine</a>
+      </li>
+          <li>
+		<a href="https://www.nursing.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Nursing">Nursing</a>
+      </li>
+          <li>
+		<a href="https://www.pharmacy.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Pharmacy">Pharmacy</a>
+      </li>
+          <li>
+		<a href="https://www.gspia.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Public &amp; Intl Affairs">Public &amp; Intl Affairs</a>
+      </li>
+          <li>
+		<a href="https://publichealth.pitt.edu/" class="data-gtm-utilityNavCategory" data-contentTitle="Public Health">Public Health</a>
+      </li>
+          <li>
+		<a href="https://www.socialwork.pitt.edu/" class="data-gtm-utilityNavCategory" data-contentTitle="Social Work">Social Work</a>
+      </li>
+        </ul>
+
+
+
+  </div>
+
+  </div>
+
+  </div>
+<div id="block-hamburgermenulower" class="hamburger-menu-lower block block-blockgroup block-block-grouphamburger-menu-lower">
+
+
+      <div id="block-hamburgermenulowercolumn1" class="hamburger-menu-lower-column block block-blockgroup block-block-grouphamburger-menu-lower-column-1">
+
+
+            <button is="menu-blockinfo-menu-btn" class="collapse-trigger--md collapsed hamburger-menu-header-btn" role="tab" data-toggle="collapse" data-target="#menu-blockinfo-menu" aria-expanded="false" aria-controls="menu-blockinfo-menu" data-gtm="">Info For</button>
+<div class="collapse-target--md collapse" id="menu-blockinfo-menu" role="tabpanel" aria-labelledby="menu-blockinfo-menu-btn">
+
+
+  <div  id="block-infomenu-2-menu" class="hamburger-menu-header">Info For</div>
+
+
+
+            <ul class="hamburger-menu-list">
+      <li class="hamburger-menu-list-wrapper">
+        <ul class="hamburger-menu-list">
+                              <li>
+			<a href="http://coronavirus.pitt.edu/" class="data-gtm-utilityNavCategory" data-contentTitle="COVID-19 Response">COVID-19 Response</a>
+            </li>
+                                        <li>
+			<a href="https://www.alumni.pitt.edu/s/1729/alumni/home.aspx?gid=2&amp;pgid=2381" class="data-gtm-utilityNavCategory" data-contentTitle="Alumni">Alumni</a>
+            </li>
+                                                                                </ul>
+        <ul class="hamburger-menu-list">
+                                                                  <li>
+			<a href="https://www.community.pitt.edu/" class="data-gtm-utilityNavCategory" data-contentTitle="Community">Community</a>
+            </li>
+                                        <li>
+			<a href="/global" class="data-gtm-utilityNavCategory" data-contentTitle="Global">Global</a>
+            </li>
+                                        <li>
+			<a href="https://www.sustainable.pitt.edu/" class="data-gtm-utilityNavCategory" data-contentTitle="Sustainability">Sustainability</a>
+            </li>
+                          </ul>
+      </li>
+    </ul>
+
+
+
+
+  </div>
+
+  </div>
+<div id="block-hamburgermenulowercolumn2" class="hamburger-menu-lower-column block block-blockgroup block-block-grouphamburger-menu-lower-column-2">
+
+
+      <div id="block-socialmedialinks-4" class="hamburger-menu-social block-social-media-links block block-social-media-links-block">
+
+
+
+
+<ul class="social-media-links--platforms platforms inline horizontal">
+      <li>
+      <a class="social-media-link-icon--twitter" href="https://www.twitter.com/PittTweet"  >
+          <i class="micon fa-twitter" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Twitter</span>
+      </a>
+    </li>
+      <li>
+      <a class="social-media-link-icon--instagram" href="https://www.instagram.com/pittofficial"  >
+          <i class="micon fa-instagram" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Instagram</span>
+      </a>
+    </li>
+      <li>
+      <a class="social-media-link-icon--facebook" href="https://www.facebook.com/upitt"  >
+          <i class="micon fa-facebook" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Facebook</span>
+      </a>
+    </li>
+      <li>
+      <a class="social-media-link-icon--youtube" href="https://www.youtube.com/user/pittweb"  >
+          <i class="micon fa-youtube" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Youtube</span>
+      </a>
+    </li>
+  </ul>
+
+  </div>
+
+  </div>
+
+  </div>
+
+                  </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="pittwire-search-menu" class="modal modal--side navigation-slide-menu right" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <!-- modal - header -->
+      <div class="modal-header">
+        <!-- modal - dismiss -->
+        <button type="button" class="modal-dismiss-button" data-dismiss="modal" aria-label="Close" data-gtm="">
+          <span class="sr-only">Close</span>
+        </button>
+      </div>
+      <!-- modal - body -->
+      <div class="modal-body">
+        <div class="search-menu-wrapper">
+          <div class="search-menu-header">Search Pittwire</div>
+
+          <div class="search-menu-typeahead-wrapper">
+            <div class="search-menu-typeahead">
+              <label for="main-search-nav" class="sr-only">Search</label>
+
+              <!-- cse markup -->
+              <div class="gcse-searchbox-only" data-enableHistory="true" data-autoCompleteMaxCompletions="5" data-autoCompleteMatchType="any" data-resultsUrl="/pittwire/search-results"></div>
+
+            </div>
+
+          </div>
+
+
+          <div class="search-menu-footer">
+            <a href="https://www.pitt.edu/search-results" class="arrow">Search www.pitt.edu</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+<main id="content" class="main-container">
+    <a id="main-content" tabindex="-1"></a>
+    <div class="layout--right-rail pittwire">
+
+        <section class="main-content">
+              <div class="region region-content">
+    <div id="block-pitt-pittwire-mainpagecontent" class="block block-system block-system-main-block">
+
+
+      <div class="views-element-container">
+<div class="view view-article-view view-id-article_view view-display-id-pittwire_news js-view-dom-id-354752d2c3352e3743478ec9b00f481cc94c2ca8c12c06a967782be90883dd63">
+            <div class="page-header">
+            <div class="page-header-container">
+                                    <h1 class="page-header-title">Features &amp; Articles
+</h1>
+                            </div>
+        </div>
+                <div class="filter-module">
+            <div class="filter-container">
+                <div class="filter-wrapper">
+                    <h2 class="filter-wrapper-title">Filter By</h2>
+                    <form class="views-exposed-form bef-exposed-form" data-bef-auto-submit-full-form="" data-bef-auto-submit="" data-bef-auto-submit-delay="1000" novalidate="novalidate" data-drupal-selector="views-exposed-form-article-view-pittwire-news" action="/pittwire/news/features-articles" method="get" id="views-exposed-form-article-view-pittwire-news" accept-charset="UTF-8">
+  <div class="filter-grid">
+
+  <fieldset class="js-form-item js-form-type-select form-type-select js-form-item-field-topics-target-id form-item-field-topics-target-id form-group">
+          <label for="edit-field-topics-target-id">Search by topic</label>
+                <select data-drupal-selector="edit-field-topics-target-id" id="edit-field-topics-target-id" name="field_topics_target_id" class="form-select form-control"><option value="All">Topics</option><option value="432" selected="selected">University News</option><option value="2">Health and Wellness</option><option value="391">Technology &amp; Science</option><option value="4">Arts and Humanities</option><option value="6">Community Impact</option><option value="1">Innovation and Research</option><option value="9">Global</option><option value="8">Diversity, Equity, and Inclusion</option><option value="12">Our City/Our Campus</option><option value="7">Teaching &amp; Learning</option><option value="440">Space</option><option value="441">Ukraine</option><option value="470">Sustainability</option></select>
+                  </fieldset>
+
+  <fieldset class="js-form-item js-form-type-select form-type-select js-form-item-field-article-date-value form-item-field-article-date-value form-group">
+          <label for="edit-field-article-date-value">Search by date</label>
+                <select data-drupal-selector="edit-field-article-date-value" id="edit-field-article-date-value" name="field_article_date_value" class="form-select form-control"><option value="">Year</option><option value="2012">2012</option><option value="2015">2015</option><option value="2016">2016</option><option value="2017">2017</option><option value="2018">2018</option><option value="2019">2019</option><option value="2020" selected="selected">2020</option><option value="2021">2021</option><option value="2022">2022</option><option value="2023">2023</option><option value="2024">2024</option></select>
+                  </fieldset>
+
+  <fieldset class="form-title-search js-form-item js-form-type-textfield form-type-textfield js-form-item-title form-item-title form-no-label form-group">
+          <label for="edit-title" class="sr-only">Search News</label>
+                <input placeholder="Search News" data-bef-auto-submit-exclude="" data-drupal-selector="edit-title" type="text" id="edit-title" name="title" value="" size="30" maxlength="128" class="form-text form-control" />
+
+                  </fieldset>
+<input data-drupal-selector="edit-field-category-target-id" type="hidden" name="field_category_target_id" value="All" class="form-control" />
+<div data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-group" id="edit-actions"><input data-bef-auto-submit-click="" data-drupal-selector="edit-submit-article-view" type="submit" id="edit-submit-article-view" value="Apply" class="button js-form-submit form-submit btn btn-primary form-control" />
+</div>
+
+    <button type="button" class="filter-search-btn"><span class="icon-search"></span> <span class="sr-only">Search News</span></button>
+</div>
+
+</form>
+
+                </div>
+            </div>
+        </div>
+
+            <div class="listing-wrapper">
+            <div class="listing-container">
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/university-pittsburgh-library-system-acquires-archive-renowned-playwright-august-wilson">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2022-08/wilson-photograph_hero.jpg?h=9d225486&amp;itok=uwlWyV9V" alt="Wilson standing in front of a wall papered with notebook pages" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/university-pittsburgh-library-system-acquires-archive-renowned-playwright-august-wilson">      	  	  University of Pittsburgh Library System acquires archive of renowned playwright August Wilson
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  The late playwright and Pittsburgh native is best known for his unprecedented American Century Cycle—10 plays that convey the Black experience in each decade of the 20th century. All 10 of the plays
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Arts and Humanities
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/more-100-new-flexible-course-offerings-2020">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-01/dji_0038_1_hero.jpg?h=de836872&amp;itok=dWzmCUkc" alt="The Cathedral of Learning towers over Pitt&#039;s campus" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/more-100-new-flexible-course-offerings-2020">      	  	  Pitt will offer more than 100 new flexible courses for 2020
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  From Afrofuturism in music to a new graduate certificate on transnational Asia, this academic year is set to offer students even more academic opportunities.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				Kenneth P. Dietrich School of Arts and Sciences
+				</li>
+		      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Global
+				</li>
+		      		        <li class="field__item">
+				Faculty
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/john-wallace-named-vice-provost-faculty-diversity-and-development">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2023-06/20181018_ao_2528_cec_opening_0474_smallhero.jpg?h=d8076212&amp;itok=C7eappS7" alt="John Wallace addresses a crowd at a podium" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/john-wallace-named-vice-provost-faculty-diversity-and-development">      	  	  John Wallace named vice provost for faculty diversity and development
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  John Wallace, the David E. Epperson Endowed Chair in the School of Social Work, will serve as vice provost for faculty diversity and development beginning July 1, 2020.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Diversity, Equity, and Inclusion
+				</li>
+		      		        <li class="field__item">
+				School of Social Work
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/pitt-pride-university-again-ranked-best-college-lgbtq-students">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/article-images/getty_pride-1145840298_insidedisplay.jpg?h=b9fbf23c&amp;itok=1azzApGH" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/pitt-pride-university-again-ranked-best-college-lgbtq-students">      	  	  The University is again ranked a Best College for LGBTQ+ Students
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  Here's a firsthand account of how one student found his place at Pitt.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Diversity, Equity, and Inclusion
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card video">
+            <figure>
+          <a href="/pittwire/features-articles/track-and-field-olympian-reflects-time-pitt-plans-new-facilities">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2023-01/3035_bot_dinner_md_0147_smallhero_0.jpg?h=d8076212&amp;itok=xJMEpQ6d" alt="Douglas sits behind a desk wearing a grey suit" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/track-and-field-olympian-reflects-time-pitt-plans-new-facilities">      	  	  Track and field Olympian reflects on time at Pitt and plans for new facilities
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  Alumnus Herb Douglas (EDUC ’48, ’50G), the oldest living African American Olympic medalist, says plans for new training spaces for athletes will bring recruiting and Pitt Athletics to new heights.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Athletics
+				</li>
+		      	    </ul>
+
+</div>
+
+            </div>
+        </div>
+
+
+                    </div>
+</div>
+
+  </div>
+
+  </div>
+
+        </section>
+
+        <div class="right-rail">
+            <div class="right-rail-content">
+                  <div class="region region-right-sidebar">
+    <div id="block-manualfeaturedcards" class="block block-fixed-block-content block-fixed-block-contentmanual-featured-cards">
+
+
+
+
+<div class="news-card video">
+            <figure>
+            <a href="/pittwire/features-articles/gabel-council-competitiveness-education">
+                      	  	    <img src="/sites/default/files/styles/news_card_sidebar/public/2023-11/20220223_ao_machine_shop_0183_hero.jpg?h=b273ae4c&amp;itok=5WHtZ_O5" alt="People gather around a machine that makes quantum computing parts" loading="lazy" typeof="foaf:Image" class="image-style-news-card-sidebar" />
+
+
+
+
+            </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/gabel-council-competitiveness-education">      	  	  Chancellor Gabel highlights higher education’s role in keeping America competitive
+	        </a></h2>
+</div>
+
+
+
+<div class="news-card image">
+            <figure>
+            <a href="/pittwire/features-articles/shadow-bandits-eclipse-chasing">
+                      	  	    <img src="/sites/default/files/styles/news_card_sidebar/public/2023-10/20230909_ta_shadow-bandits_allegheny-observatory_0115_hero.jpg?h=77bf0f74&amp;itok=SMFN0NJ7" alt="One student fills a large weather balloon with air while another holds it above her head" loading="lazy" typeof="foaf:Image" class="image-style-news-card-sidebar" />
+
+
+
+
+            </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/shadow-bandits-eclipse-chasing">      	  	  These Pitt students are following the eclipse to Texas
+	        </a></h2>
+</div>
+
+
+
+
+  </div>
+
+    <div class="pittwire-heading">Trending</div>
+    <div><div class="view view-trending-articles view-id-trending_articles view-display-id-trending js-view-dom-id-f5b638902a2ec34b8aa9e519454627b07abcd2583f78b05b35f17cfa1f5e8ab0">
+
+
+
+      <div class="view-content">
+          <div class="news-card views-row"><div class="views-field views-field-title"><span class="field-content"><h2 class="news-card-title"><a href="/pittwire/announcements-and-updates/new-winter-commencement-date-2024">Pitt’s winter commencement is now on Dec. 18</a></h2>
+</span></div></div>
+    <div class="news-card views-row"><div class="views-field views-field-title"><span class="field-content"><h2 class="news-card-title"><a href="/pittwire/announcements-and-updates/community-engaged-scholarship-project-development-cohort-2024">Apply for a program on developing community engaged scholarship projects</a></h2>
+</span></div></div>
+    <div class="news-card views-row"><div class="views-field views-field-title"><span class="field-content"><h2 class="news-card-title"><a href="/pittwire/accolades-honors/bradford-college-distinction-10-years">Pitt-Bradford has been a College of Distinction for a decade</a></h2>
+</span></div></div>
+
+    </div>
+
+          </div>
+</div>
+
+<!-- Subscribe Module -->
+<div id="block-subscribetopittwire" class="subscribe-wrapper block block-fixed-block-content block-fixed-block-contentsubscribe-to-pittwire">
+    <div class="subscribe-inner">
+          	        <figure class="field field--type-entity-reference field--label-hidden field__item">
+	  	    <img src="/sites/default/files/styles/subscription_callout/public/2021-07/img-pittwire-subscribe.png?h=7f3918f9&amp;itok=hC3ZYfSz" alt="FPO Tower" loading="lazy" typeof="foaf:Image" class="image-style-subscription-callout" />
+
+
+
+	  	  </figure>
+
+    <div class="subscribe-content">
+            	        <h2 class="subscribe-content-title field field--type-string field--label-hidden field__item">
+	  	  Subscribe to Pittwire Today
+	  	  </h2>
+
+            	  	  Get the most interesting and important stories from the University of Pittsburgh.
+
+    </div>
+  </div>
+  <div class="subscribe-form">
+    <div class="subscribe-form-btn">
+      <a href="/subscribe-pittwire" class="btn-submit">      	  	  Subscribe
+	        </a>
+    </div>
+  </div>
+  </div>
+
+  </div>
+
+            </div>
+        </div>
+    </div>
+
+</main>
+
+  <footer class="footer">
+                	        <div class="footer-bg field field--type-entity-reference field--label-hidden field__item">
+	  	    <img src="/sites/default/files/styles/footer_background/public/2021-03/img-bridge.png?itok=YCj_wGW3" alt="Bridge Icon" loading="lazy" typeof="foaf:Image" class="image-style-footer-background" />
+
+
+
+	  	  </div>
+
+  <div id="block-pitt-pittwire-footerblocks" class="footer-container">
+      <!-- Logo and Links -->
+<div class="footer-navigation" data-max-columns="2">
+      <div id="block-pitt-pittwire-sitebranding-2" class="footer-navigation-logo block block-system block-system-branding-block">
+
+
+        <a href="/" title="University of Pittsburgh" rel="home" class="site-logo">
+      <img src="/themes/custom/pitt_pittwire/logo.svg" alt="University of Pittsburgh" />
+    </a>
+    </div>
+<nav role="navigation" aria-labelledby="block-globalmenu-2-menu" id="block-globalmenu-2" class="menu--footer block block-menu navigation menu--global-menu">
+
+  <h2 class="visually-hidden" id="block-globalmenu-2-menu">Global Menu</h2>
+
+
+
+        <ul>
+          <li>
+        <a href="https://admissions.pitt.edu/apply/">Apply</a>
+      </li>
+          <li>
+        <a href="https://admissions.pitt.edu/visit/unscripted/">Visit</a>
+      </li>
+          <li>
+        <a href="https://www.giveto.pitt.edu/s/1729/18/home-giving.aspx?gid=2&amp;pgid=2135">Give</a>
+      </li>
+          <li>
+        <a href="/pittwire" data-drupal-link-system-path="node/18">Pittwire</a>
+      </li>
+          <li>
+        <a href="http://calendar.pitt.edu/">Events</a>
+      </li>
+        </ul>
+
+
+
+  </nav>
+
+  </div>
+<div class="footer-main" data-max-columns="2">
+      <!-- Footer Main Menu -->
+<div class="footer-sitemap" data-max-columns="2">
+
+                    <ul>
+              <li>
+		<a href="/about" class="data-gtm-footerLinksCategory">About</a>
+        </li>
+                        <li>
+		<a href="/academics" class="data-gtm-footerLinksCategory">Academics</a>
+        </li>
+                        <li>
+		<a href="/admissions" class="data-gtm-footerLinksCategory">Admissions</a>
+        </li>
+            </ul>
+                      <ul>
+              <li>
+		<a href="/research" class="data-gtm-footerLinksCategory">Research</a>
+        </li>
+                        <li>
+		<a href="/student-life" class="data-gtm-footerLinksCategory">Life at Pitt</a>
+        </li>
+                        <li>
+		<a href="http://pittsburghpanthers.com/" class="data-gtm-footerLinksCategory">Athletics</a>
+        </li>
+            </ul>
+
+
+<!-- End Main Menu -->
+
+  </div>
+<div id="block-footerquicklinksandcontact-2" class="block block-blockgroup block-block-groupfooter-quick-links-and-contact">
+
+
+      <!-- Quick Links and Contact Info -->
+<div class="footer-quicklinks">
+  <!-- Quick Links -->
+  <div class="collapse--secondary" data-max-columns="2">
+      <div id="block-pitt-pittwire-footerquicklinkscolumn1" class="block block-blockgroup block-block-groupfooter-quick-links-column-1">
+
+
+      <!-- collapse item -->
+<div class="footer-quicklinks-item">
+  <button id="quick-links-resources" class="collapse-trigger--md collapsed footer-quicklinks-item-header" role="tab" data-toggle="collapse" data-target="#collapse-item-quick-links-resources" aria-expanded="false" aria-controls="collapse-item-quick-links-resources" data-gtm="">Quick Links &amp; Resources</button>
+  <div id="collapse-item-quick-links-resources" class="collapse-target--md collapse" role="tabpanel" aria-labelledby="quick-links-resources">
+    <div class="collapse-content">
+      <div class="footer-quicklinks-item-header">Quick Links &amp; Resources</div>
+
+        <ul>
+            <li>
+		<a href="https://www.diversity.pitt.edu/accessibility-statement" class="data-gtm-footerLinksKPI">Accessibility Statement</a>
+        </li>
+            <li>
+		<a href="https://www.affordability.pitt.edu/" class="data-gtm-footerLinksKPI">Affordability</a>
+        </li>
+            <li>
+		<a href="https://www.join.pitt.edu/" class="data-gtm-footerLinksKPI">Careers</a>
+        </li>
+            <li>
+		<a href="/about/general-info" class="data-gtm-footerLinksKPI">Consumer Info/Achievement</a>
+        </li>
+            <li>
+		<a href="/contact" class="data-gtm-footerLinksKPI">Contact Us</a>
+        </li>
+            <li>
+		<a href="https://www.academics.pitt.edu/programs/a-z" class="data-gtm-footerLinksKPI">Departments A-Z</a>
+        </li>
+            <li>
+		<a href="https://www.diversity.pitt.edu/" class="data-gtm-footerLinksKPI">Diversity, Equity and Inclusion</a>
+        </li>
+            <li>
+		<a href="https://find.pitt.edu/" class="data-gtm-footerLinksKPI">Find People</a>
+        </li>
+            <li>
+		<a href="https://www.technology.pitt.edu/" class="data-gtm-footerLinksKPI">Information Technology</a>
+        </li>
+            <li>
+		<a href="https://www.lgbtq.pitt.edu/" class="data-gtm-footerLinksKPI">LGBTQ+</a>
+        </li>
+            <li>
+		<a href="https://www.diversity.pitt.edu/notice-nondiscrimination-and-anti-harassment-policy-statement" class="data-gtm-footerLinksKPI">Nondiscrimination and Anti-Harassment Policy</a>
+        </li>
+            <li>
+		<a href="https://www.pitt.edu/privacy-policy" class="data-gtm-footerLinksKPI">Privacy Policy</a>
+        </li>
+            <li>
+		<a href="https://www.pitt.edu/accountability" class="data-gtm-footerLinksKPI">Promoting Accountability and Trust</a>
+        </li>
+            <li>
+		<a href="http://my.pitt.edu" class="data-gtm-footerLinksKPI">My Pitt</a>
+        </li>
+        </ul>
+
+
+
+          </div>
+  </div>
+</div>
+<!-- collapse item -->
+<div class="footer-quicklinks-item">
+  <button id="regional-campuses" class="collapse-trigger--md collapsed footer-quicklinks-item-header" role="tab" data-toggle="collapse" data-target="#collapse-item-regional-campuses" aria-expanded="false" aria-controls="collapse-item-regional-campuses" data-gtm="">Regional Campuses</button>
+  <div id="collapse-item-regional-campuses" class="collapse-target--md collapse" role="tabpanel" aria-labelledby="regional-campuses">
+    <div class="collapse-content">
+      <div class="footer-quicklinks-item-header">Regional Campuses</div>
+
+        <ul>
+            <li>
+		<a href="https://upb.pitt.edu/" class="data-gtm-footerLinksKPI">Bradford</a>
+        </li>
+            <li>
+		<a href="http://www.greensburg.pitt.edu/" class="data-gtm-footerLinksKPI">Greensburg</a>
+        </li>
+            <li>
+		<a href="https://www.johnstown.pitt.edu/" class="data-gtm-footerLinksKPI">Johnstown</a>
+        </li>
+            <li>
+		<a href="https://www.titusville.pitt.edu/" class="data-gtm-footerLinksKPI">Titusville</a>
+        </li>
+        </ul>
+
+
+
+          </div>
+  </div>
+</div>
+
+  </div>
+<div id="block-pitt-pittwire-footerquicklinkscolumn2" class="block block-blockgroup block-block-groupfooter-quick-links-column-2">
+
+
+      <!-- collapse item -->
+<div class="footer-quicklinks-item">
+  <button id="colleges-schools" class="collapse-trigger--md collapsed footer-quicklinks-item-header" role="tab" data-toggle="collapse" data-target="#collapse-item-colleges-schools" aria-expanded="false" aria-controls="collapse-item-colleges-schools" data-gtm="">Colleges &amp; Schools</button>
+  <div id="collapse-item-colleges-schools" class="collapse-target--md collapse" role="tabpanel" aria-labelledby="colleges-schools">
+    <div class="collapse-content">
+      <div class="footer-quicklinks-item-header">Colleges &amp; Schools</div>
+
+        <ul>
+            <li>
+		<a href="https://www.as.pitt.edu" class="data-gtm-footerLinksKPI">Arts &amp; Sciences</a>
+        </li>
+            <li>
+		<a href="https://www.business.pitt.edu" class="data-gtm-footerLinksKPI">Business</a>
+        </li>
+            <li>
+		<a href="https://www.sci.pitt.edu" class="data-gtm-footerLinksKPI">Computing &amp; Information</a>
+        </li>
+            <li>
+		<a href="https://www.dental.pitt.edu" class="data-gtm-footerLinksKPI">Dental Medicine</a>
+        </li>
+            <li>
+		<a href="https://www.education.pitt.edu" class="data-gtm-footerLinksKPI">Education</a>
+        </li>
+            <li>
+		<a href="https://www.engineering.pitt.edu" class="data-gtm-footerLinksKPI">Engineering</a>
+        </li>
+            <li>
+		<a href="https://www.cgs.pitt.edu" class="data-gtm-footerLinksKPI">General Studies</a>
+        </li>
+            <li>
+		<a href="https://www.shrs.pitt.edu" class="data-gtm-footerLinksKPI">Health &amp; Rehabilitation</a>
+        </li>
+            <li>
+		<a href="https://www.honors.pitt.edu" class="data-gtm-footerLinksKPI">Honors College</a>
+        </li>
+            <li>
+		<a href="https://www.law.pitt.edu" class="data-gtm-footerLinksKPI">Law</a>
+        </li>
+            <li>
+		<a href="https://www.medschool.pitt.edu" class="data-gtm-footerLinksKPI">Medicine</a>
+        </li>
+            <li>
+		<a href="https://www.nursing.pitt.edu" class="data-gtm-footerLinksKPI">Nursing</a>
+        </li>
+            <li>
+		<a href="https://www.pharmacy.pitt.edu" class="data-gtm-footerLinksKPI">Pharmacy</a>
+        </li>
+            <li>
+		<a href="https://www.gspia.pitt.edu" class="data-gtm-footerLinksKPI">Public &amp; Intl Affairs</a>
+        </li>
+            <li>
+		<a href="https://publichealth.pitt.edu/" class="data-gtm-footerLinksKPI">Public Health</a>
+        </li>
+            <li>
+		<a href="https://www.socialwork.pitt.edu/" class="data-gtm-footerLinksKPI">Social Work</a>
+        </li>
+        </ul>
+
+
+
+          </div>
+  </div>
+</div>
+
+  </div>
+
+    </div>
+</div>
+<div id="block-footercontact-2" class="footer-contact block block-blockgroup block-block-groupfooter-contact">
+
+
+      <div id="block-footersiteinformation-2" class="block block-block-content block-block-content60643064-ee6c-4394-90c4-9e061373c0d4">
+
+
+            	        <div class="field field--type-address field--label-hidden field__item">
+	  	  <p class="address" translate="no"><span class="address-line1">4200 Fifth Ave.</span><br>
+<span class="locality">Pittsburgh</span>, <span class="administrative-area">PA</span> <span class="postal-code">15260</span><br>
+<span class="country">United States</span></p>
+	  	  </div>
+	              	        <div class="field field--type-telephone field--label-hidden field__item">
+	  	  <a href="tel:+1-412-624-4141">+1 412-624-4141</a>
+	  	  </div>
+
+  </div>
+<div id="block-socialmedialinks-2" class="block-social-media-links block block-social-media-links-block">
+
+
+
+
+<ul class="social-media-links--platforms platforms inline horizontal">
+      <li>
+      <a class="social-media-link-icon--twitter" href="https://www.twitter.com/PittTweet"  target="_blank" >
+          <i class="micon fa-twitter" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Twitter</span>
+      </a>
+    </li>
+      <li>
+      <a class="social-media-link-icon--instagram" href="https://www.instagram.com/pittofficial"  target="_blank" >
+          <i class="micon fa-instagram" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Instagram</span>
+      </a>
+    </li>
+      <li>
+      <a class="social-media-link-icon--facebook" href="https://www.facebook.com/upitt"  target="_blank" >
+          <i class="micon fa-facebook" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Facebook</span>
+      </a>
+    </li>
+      <li>
+      <a class="social-media-link-icon--youtube" href="https://www.youtube.com/user/pittweb"  target="_blank" >
+          <i class="micon fa-youtube" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Youtube</span>
+      </a>
+    </li>
+  </ul>
+
+  </div>
+
+  </div>
+
+  </div>
+
+  </div>
+
+  </div>
+
+  </footer>
+
+
+
+
+
+  </div>
+
+
+    <script type="application/json" data-drupal-selector="drupal-settings-json">{"path":{"baseUrl":"\/","scriptPath":null,"pathPrefix":"","currentPath":"pittwire\/news\/features-\u0026-articles","currentPathIsAdmin":false,"isFront":false,"currentLanguage":"en","currentQuery":{"field_article_date_value":"2020","field_category_target_id":"All","field_topics_target_id":"432","title":""}},"pluralDelimiter":"\u0003","suppressDeprecationErrors":true,"ajaxPageState":{"libraries":"better_exposed_filters\/auto_submit,better_exposed_filters\/general,choices\/choices,core\/drupal.ajax,entity_overlay\/entity_overlay.behaviors,extlink\/drupal.extlink,media\/oembed.formatter,micon\/micon,paragraphs\/drupal.paragraphs.unpublished,pitt_default\/card,pitt_default\/choices,pitt_default\/global-styling,pitt_default\/media-item,pitt_default\/modal,social_media_links\/social_media_links.theme,system\/base,views\/views.module,zenny\/base,zensource_front_end\/classy.messages,zensource_front_end\/global-styling","theme":"pitt_pittwire","theme_token":"zjXQDBdTMt2mZC4y4bJWrE4DGi6Fcf67Lf6JMhH4rBU"},"ajaxTrustedUrl":{"\/pittwire\/news\/features-articles":true},"data":{"extlink":{"extTarget":false,"extTargetNoOverride":false,"extNofollow":false,"extNoreferrer":true,"extFollowNoOverride":false,"extClass":"0","extLabel":"(link is external)","extImgClass":false,"extSubdomains":true,"extExclude":"","extInclude":"","extCssExclude":"#block-socialmedialinks","extCssExplicit":"","extAlert":false,"extAlertText":"This link will take you to an external web site. We are not responsible for their content.","mailtoClass":"0","mailtoLabel":"(link sends email)","extUseFontAwesome":false,"extIconPlacement":"append","extFaLinkClasses":"fa fa-external-link","extFaMailtoClasses":"fa fa-envelope-o","whitelistedDomains":[]}},"entity_overlay":{"media_8412":{"overlay_url":"\/entity_overlay\/load\/nojs\/media\/8412\/modal","path_match":["media\/8412","\/media\/8412"],"dialog_type":"core_modal"},"media_7502":{"overlay_url":"\/entity_overlay\/load\/nojs\/media\/7502\/modal","path_match":["media\/7502","\/media\/7502"],"dialog_type":"core_modal"}},"choices":{"cssSelector":["select[multiple=multiple]\r","select#edit-field-topics-target-id\r","select#edit-field-article-date-value\r","select#edit-field-pittwire-home-hero\r","select[id*=\u0022-subform-field-featured-article\u0022]"]},"user":{"uid":0,"permissionsHash":"45709791c536f1a56041d94d00891fba6b9156605a804ed14b7a260a9fb3cf47"}}</script>
+<script src="/themes/custom/pitt_default/js/gsap/dist/gsap.min.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/gsap/dist/ScrollTrigger.min.js?v=9.3.21"></script>
+<script src="/core/assets/vendor/jquery/jquery.min.js?v=3.6.0"></script>
+<script src="/core/misc/polyfills/element.matches.js?v=9.3.21"></script>
+<script src="/core/misc/polyfills/object.assign.js?v=9.3.21"></script>
+<script src="/core/assets/vendor/css-escape/css.escape.js?v=1.5.1"></script>
+<script src="/core/assets/vendor/once/once.min.js?v=1.0.1"></script>
+<script src="/core/assets/vendor/jquery-once/jquery.once.min.js?v=2.2.3"></script>
+<script src="/core/misc/drupalSettingsLoader.js?v=9.3.21"></script>
+<script src="/core/misc/drupal.js?v=9.3.21"></script>
+<script src="/core/misc/drupal.init.js?v=9.3.21"></script>
+<script src="/core/assets/vendor/tabbable/index.umd.min.js?v=5.2.1"></script>
+<script src="/core/misc/debounce.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/collapse-native.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/collapse.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/transition.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/hoverintent.min.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/navigation.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/userInterface.js?v=9.3.21"></script>
+<script src="/themes/contrib/zensource_front_end/js/global.js?v=9.3.21"></script>
+<script src="/core/misc/jquery.once.bc.js?v=9.3.21"></script>
+<script src="/modules/contrib/extlink/extlink.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/card.js?shklz9"></script>
+<script src="/modules/contrib/entity_overlay/js/behaviors.js?v=9.3.21"></script>
+<script src="/core/misc/progress.js?v=9.3.21"></script>
+<script src="/core/modules/responsive_image/js/responsive_image.ajax.js?v=9.3.21"></script>
+<script src="/core/misc/ajax.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/media-item.js?shklz9"></script>
+<script src="/modules/contrib/better_exposed_filters/js/better_exposed_filters.js?v=4.x"></script>
+<script src="/modules/contrib/better_exposed_filters/js/auto_submit.js?v=4.x"></script>
+<script src="/libraries/choices.js/public/assets/scripts/choices.min.js?shklz9"></script>
+<script src="/themes/contrib/zenny/js/choices.js?shklz9"></script>
+<script src="/themes/custom/pitt_default/js/filter-search.js?shklz9"></script>
+<script src="/themes/custom/pitt_default/js/modal-native.js?shklz9"></script>
+<script src="/themes/custom/pitt_default/js/modal.js?shklz9"></script>
+
+  <script type="text/javascript">window.NREUM||(NREUM={});NREUM.info={"beacon":"bam.nr-data.net","licenseKey":"NRJS-32db2f37a7e1f41235a","applicationID":"1009016335","transactionName":"NAAAYUNYCBFXVEddVw1KI1ZFUAkMGXNBQUgCCT5DWFwREWplXEFMCgsFaWdQAxVmVlRRewwLFkdeVQoHRBoNXFkNAQ5Q","queueTime":0,"applicationTime":142,"atts":"GEcDFwtCGx8=","errorBeacon":"bam.nr-data.net","agent":""}</script></body>
+</html>

--- a/tests/samples/news_university_news_features_articles_fulbright.html
+++ b/tests/samples/news_university_news_features_articles_fulbright.html
@@ -1,0 +1,1209 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr" prefix="content: http://purl.org/rss/1.0/modules/content/  dc: http://purl.org/dc/terms/  foaf: http://xmlns.com/foaf/0.1/  og: http://ogp.me/ns#  rdfs: http://www.w3.org/2000/01/rdf-schema#  schema: http://schema.org/  sioc: http://rdfs.org/sioc/ns#  sioct: http://rdfs.org/sioc/types#  skos: http://www.w3.org/2004/02/skos/core#  xsd: http://www.w3.org/2001/XMLSchema# ">
+  <head>
+    <meta charset="utf-8" /><script type="text/javascript">(window.NREUM||(NREUM={})).init={privacy:{cookies_enabled:true},ajax:{deny_list:["bam.nr-data.net"]}};(window.NREUM||(NREUM={})).loader_config={licenseKey:"NRJS-32db2f37a7e1f41235a",applicationID:"1009016335"};;/*! For license information please see nr-loader-rum-1.264.0.min.js.LICENSE.txt */
+(()=>{var e,t,r={2983:(e,t,r)=>{"use strict";r.d(t,{D0:()=>m,gD:()=>y,Vp:()=>s,fr:()=>S,jD:()=>I,hR:()=>E,xN:()=>b,x1:()=>c,aN:()=>R,V:()=>j});var n=r(384),i=r(7864);const o={beacon:n.NT.beacon,errorBeacon:n.NT.errorBeacon,licenseKey:void 0,applicationID:void 0,sa:void 0,queueTime:void 0,applicationTime:void 0,ttGuid:void 0,user:void 0,account:void 0,product:void 0,extra:void 0,jsAttributes:{},userAttributes:void 0,atts:void 0,transactionName:void 0,tNamePlain:void 0},a={};function s(e){if(!e)throw new Error("All info objects require an agent identifier!");if(!a[e])throw new Error("Info for ".concat(e," was never set"));return a[e]}function c(e,t){if(!e)throw new Error("All info objects require an agent identifier!");a[e]=(0,i.a)(t,o);const r=(0,n.nY)(e);r&&(r.info=a[e])}var u=r(993);const l=e=>{if(!e||"string"!=typeof e)return!1;try{document.createDocumentFragment().querySelector(e)}catch{return!1}return!0};var d=r(2614),g=r(944);const f="[data-nr-mask]",h=()=>{const e={mask_selector:"*",block_selector:"[data-nr-block]",mask_input_options:{color:!1,date:!1,"datetime-local":!1,email:!1,month:!1,number:!1,range:!1,search:!1,tel:!1,text:!1,time:!1,url:!1,week:!1,textarea:!1,select:!1,password:!0}};return{ajax:{deny_list:void 0,block_internal:!0,enabled:!0,harvestTimeSeconds:10,autoStart:!0},distributed_tracing:{enabled:void 0,exclude_newrelic_header:void 0,cors_use_newrelic_header:void 0,cors_use_tracecontext_headers:void 0,allowed_origins:void 0},feature_flags:[],generic_events:{enabled:!0,harvestTimeSeconds:30,autoStart:!0},harvest:{tooManyRequestsDelay:60},jserrors:{enabled:!0,harvestTimeSeconds:10,autoStart:!0},logging:{enabled:!0,harvestTimeSeconds:10,autoStart:!0,level:u.p_.INFO},metrics:{enabled:!0,autoStart:!0},obfuscate:void 0,page_action:{enabled:!0},page_view_event:{enabled:!0,autoStart:!0},page_view_timing:{enabled:!0,harvestTimeSeconds:30,long_task:!1,autoStart:!0},privacy:{cookies_enabled:!0},proxy:{assets:void 0,beacon:void 0},session:{expiresMs:d.wk,inactiveMs:d.BB},session_replay:{autoStart:!0,enabled:!1,harvestTimeSeconds:60,preload:!1,sampling_rate:10,error_sampling_rate:100,collect_fonts:!1,inline_images:!1,inline_stylesheet:!0,fix_stylesheets:!0,mask_all_inputs:!0,get mask_text_selector(){return e.mask_selector},set mask_text_selector(t){l(t)?e.mask_selector="".concat(t,",").concat(f):""===t||null===t?e.mask_selector=f:(0,g.R)(5,t)},get block_class(){return"nr-block"},get ignore_class(){return"nr-ignore"},get mask_text_class(){return"nr-mask"},get block_selector(){return e.block_selector},set block_selector(t){l(t)?e.block_selector+=",".concat(t):""!==t&&(0,g.R)(6,t)},get mask_input_options(){return e.mask_input_options},set mask_input_options(t){t&&"object"==typeof t?e.mask_input_options={...t,password:!0}:(0,g.R)(7,t)}},session_trace:{enabled:!0,harvestTimeSeconds:10,autoStart:!0},soft_navigations:{enabled:!0,harvestTimeSeconds:10,autoStart:!0},spa:{enabled:!0,harvestTimeSeconds:10,autoStart:!0},ssl:void 0}},p={},v="All configuration objects require an agent identifier!";function m(e){if(!e)throw new Error(v);if(!p[e])throw new Error("Configuration for ".concat(e," was never set"));return p[e]}function b(e,t){if(!e)throw new Error(v);p[e]=(0,i.a)(t,h());const r=(0,n.nY)(e);r&&(r.init=p[e])}function y(e,t){if(!e)throw new Error(v);var r=m(e);if(r){for(var n=t.split("."),i=0;i<n.length-1;i++)if("object"!=typeof(r=r[n[i]]))return;r=r[n[n.length-1]]}return r}const w={accountID:void 0,trustKey:void 0,agentID:void 0,licenseKey:void 0,applicationID:void 0,xpid:void 0},A={};function R(e,t){if(!e)throw new Error("All loader-config objects require an agent identifier!");A[e]=(0,i.a)(t,w);const r=(0,n.nY)(e);r&&(r.loader_config=A[e])}const E=(0,n.dV)().o;var x=r(6154),_=r(9324);const N={buildEnv:_.F3,distMethod:_.Xs,version:_.xv,originTime:x.WN},T={customTransaction:void 0,disabled:!1,isolatedBacklog:!1,loaderType:void 0,maxBytes:3e4,onerror:void 0,origin:""+x.gm.location,ptid:void 0,releaseIds:{},appMetadata:{},session:void 0,denyList:void 0,harvestCount:0,timeKeeper:void 0},k={};function S(e){if(!e)throw new Error("All runtime objects require an agent identifier!");if(!k[e])throw new Error("Runtime for ".concat(e," was never set"));return k[e]}function j(e,t){if(!e)throw new Error("All runtime objects require an agent identifier!");k[e]={...(0,i.a)(t,T),...N};const r=(0,n.nY)(e);r&&(r.runtime=k[e])}function I(e){return function(e){try{const t=s(e);return!!t.licenseKey&&!!t.errorBeacon&&!!t.applicationID}catch(e){return!1}}(e)}},7864:(e,t,r)=>{"use strict";r.d(t,{a:()=>i});var n=r(944);function i(e,t){try{if(!e||"object"!=typeof e)return(0,n.R)(3);if(!t||"object"!=typeof t)return(0,n.R)(4);const r=Object.create(Object.getPrototypeOf(t),Object.getOwnPropertyDescriptors(t)),o=0===Object.keys(r).length?e:r;for(let a in o)if(void 0!==e[a])try{if(null===e[a]){r[a]=null;continue}Array.isArray(e[a])&&Array.isArray(t[a])?r[a]=Array.from(new Set([...e[a],...t[a]])):"object"==typeof e[a]&&"object"==typeof t[a]?r[a]=i(e[a],t[a]):r[a]=e[a]}catch(e){(0,n.R)(1,e)}return r}catch(e){(0,n.R)(2,e)}}},9324:(e,t,r)=>{"use strict";r.d(t,{F3:()=>i,Xs:()=>o,xv:()=>n});const n="1.264.0",i="PROD",o="CDN"},6154:(e,t,r)=>{"use strict";r.d(t,{OF:()=>c,RI:()=>i,Vr:()=>l,WN:()=>d,bv:()=>o,gm:()=>a,mw:()=>s,sb:()=>u});var n=r(1863);const i="undefined"!=typeof window&&!!window.document,o="undefined"!=typeof WorkerGlobalScope&&("undefined"!=typeof self&&self instanceof WorkerGlobalScope&&self.navigator instanceof WorkerNavigator||"undefined"!=typeof globalThis&&globalThis instanceof WorkerGlobalScope&&globalThis.navigator instanceof WorkerNavigator),a=i?window:"undefined"!=typeof WorkerGlobalScope&&("undefined"!=typeof self&&self instanceof WorkerGlobalScope&&self||"undefined"!=typeof globalThis&&globalThis instanceof WorkerGlobalScope&&globalThis),s=Boolean("hidden"===a?.document?.visibilityState),c=/iPad|iPhone|iPod/.test(a.navigator?.userAgent),u=c&&"undefined"==typeof SharedWorker,l=((()=>{const e=a.navigator?.userAgent?.match(/Firefox[/\s](\d+\.\d+)/);Array.isArray(e)&&e.length>=2&&e[1]})(),!!a.navigator?.sendBeacon),d=Date.now()-(0,n.t)()},4777:(e,t,r)=>{"use strict";r.d(t,{J:()=>o});var n=r(944);const i={agentIdentifier:"",ee:void 0};class o{constructor(e){try{if("object"!=typeof e)return(0,n.R)(8);this.sharedContext={},Object.assign(this.sharedContext,i),Object.entries(e).forEach((e=>{let[t,r]=e;Object.keys(i).includes(t)&&(this.sharedContext[t]=r)}))}catch(e){(0,n.R)(9,e)}}}},1687:(e,t,r)=>{"use strict";r.d(t,{Ak:()=>s,Ze:()=>l,x3:()=>c});var n=r(7836),i=r(3606),o=r(860);const a={};function s(e,t){const r={staged:!1,priority:o.P[t]||0};u(e),a[e].get(t)||a[e].set(t,r)}function c(e,t){e&&a[e]&&(a[e].get(t)&&a[e].delete(t),g(e,t,!1),a[e].size&&d(e))}function u(e){if(!e)throw new Error("agentIdentifier required");a[e]||(a[e]=new Map)}function l(){let e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:"",t=arguments.length>1&&void 0!==arguments[1]?arguments[1]:"feature",r=arguments.length>2&&void 0!==arguments[2]&&arguments[2];if(u(e),!e||!a[e].get(t)||r)return g(e,t);a[e].get(t).staged=!0,d(e)}function d(e){const t=Array.from(a[e]);t.every((e=>{let[t,r]=e;return r.staged}))&&(t.sort(((e,t)=>e[1].priority-t[1].priority)),t.forEach((t=>{let[r]=t;a[e].delete(r),g(e,r)})))}function g(e,t){let r=!(arguments.length>2&&void 0!==arguments[2])||arguments[2];const o=e?n.ee.get(e):n.ee,a=i.i.handlers;if(!o.aborted&&o.backlog&&a){if(r){const e=o.backlog[t],r=a[t];if(r){for(let t=0;e&&t<e.length;++t)f(e[t],r);Object.entries(r).forEach((e=>{let[t,r]=e;Object.values(r||{}).forEach((e=>{e[0].on(t,e[1])}))}))}}o.isolatedBacklog||delete a[t],o.backlog[t]=null,o.emit("drain-"+t,[])}}function f(e,t){var r=e[1];Object.values(t[r]||{}).forEach((t=>{var r=e[0];if(t[0]===r){var n=t[1],i=e[3],o=e[2];n.apply(i,o)}}))}},7836:(e,t,r)=>{"use strict";r.d(t,{P:()=>c,ee:()=>u});var n=r(384),i=r(8990),o=r(2983),a=r(2646),s=r(5607);const c="nr@context:".concat(s.W),u=function e(t,r){var n={},s={},l={},d=!1;try{d=16===r.length&&(0,o.fr)(r).isolatedBacklog}catch(e){}var g={on:h,addEventListener:h,removeEventListener:function(e,t){var r=n[e];if(!r)return;for(var i=0;i<r.length;i++)r[i]===t&&r.splice(i,1)},emit:function(e,r,n,i,o){!1!==o&&(o=!0);if(u.aborted&&!i)return;t&&o&&t.emit(e,r,n);for(var a=f(n),c=p(e),l=c.length,d=0;d<l;d++)c[d].apply(a,r);var h=m()[s[e]];h&&h.push([g,e,r,a]);return a},get:v,listeners:p,context:f,buffer:function(e,t){const r=m();if(t=t||"feature",g.aborted)return;Object.entries(e||{}).forEach((e=>{let[n,i]=e;s[i]=t,t in r||(r[t]=[])}))},abort:function(){g._aborted=!0,Object.keys(g.backlog).forEach((e=>{delete g.backlog[e]}))},isBuffering:function(e){return!!m()[s[e]]},debugId:r,backlog:d?{}:t&&"object"==typeof t.backlog?t.backlog:{},isolatedBacklog:d};return Object.defineProperty(g,"aborted",{get:()=>{let e=g._aborted||!1;return e||(t&&(e=t.aborted),e)}}),g;function f(e){return e&&e instanceof a.y?e:e?(0,i.I)(e,c,(()=>new a.y(c))):new a.y(c)}function h(e,t){n[e]=p(e).concat(t)}function p(e){return n[e]||[]}function v(t){return l[t]=l[t]||e(g,t)}function m(){return g.backlog}}(void 0,"globalEE"),l=(0,n.Zm)();l.ee||(l.ee=u)},2646:(e,t,r)=>{"use strict";r.d(t,{y:()=>n});class n{constructor(e){this.contextId=e}}},9908:(e,t,r)=>{"use strict";r.d(t,{d:()=>n,p:()=>i});var n=r(7836).ee.get("handle");function i(e,t,r,i,o){o?(o.buffer([e],i),o.emit(e,t,r)):(n.buffer([e],i),n.emit(e,t,r))}},3606:(e,t,r)=>{"use strict";r.d(t,{i:()=>o});var n=r(9908);o.on=a;var i=o.handlers={};function o(e,t,r,o){a(o||n.d,i,e,t,r)}function a(e,t,r,i,o){o||(o="feature"),e||(e=n.d);var a=t[o]=t[o]||{};(a[r]=a[r]||[]).push([e,i])}},3878:(e,t,r)=>{"use strict";r.d(t,{DD:()=>c,jT:()=>a,sp:()=>s});var n=r(6154);let i=!1,o=!1;try{const e={get passive(){return i=!0,!1},get signal(){return o=!0,!1}};n.gm.addEventListener("test",null,e),n.gm.removeEventListener("test",null,e)}catch(e){}function a(e,t){return i||o?{capture:!!e,passive:i,signal:t}:!!e}function s(e,t){let r=arguments.length>2&&void 0!==arguments[2]&&arguments[2],n=arguments.length>3?arguments[3]:void 0;window.addEventListener(e,t,a(r,n))}function c(e,t){let r=arguments.length>2&&void 0!==arguments[2]&&arguments[2],n=arguments.length>3?arguments[3]:void 0;document.addEventListener(e,t,a(r,n))}},5607:(e,t,r)=>{"use strict";r.d(t,{W:()=>n});const n=(0,r(9566).bz)()},9566:(e,t,r)=>{"use strict";r.d(t,{LA:()=>s,bz:()=>a});var n=r(6154);const i="xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx";function o(e,t){return e?15&e[t]:16*Math.random()|0}function a(){const e=n.gm?.crypto||n.gm?.msCrypto;let t,r=0;return e&&e.getRandomValues&&(t=e.getRandomValues(new Uint8Array(30))),i.split("").map((e=>"x"===e?o(t,r++).toString(16):"y"===e?(3&o()|8).toString(16):e)).join("")}function s(e){const t=n.gm?.crypto||n.gm?.msCrypto;let r,i=0;t&&t.getRandomValues&&(r=t.getRandomValues(new Uint8Array(e)));const a=[];for(var s=0;s<e;s++)a.push(o(r,i++).toString(16));return a.join("")}},2614:(e,t,r)=>{"use strict";r.d(t,{BB:()=>a,H3:()=>n,g:()=>u,iL:()=>c,tS:()=>s,uh:()=>i,wk:()=>o});const n="NRBA",i="SESSION",o=144e5,a=18e5,s={STARTED:"session-started",PAUSE:"session-pause",RESET:"session-reset",RESUME:"session-resume",UPDATE:"session-update"},c={SAME_TAB:"same-tab",CROSS_TAB:"cross-tab"},u={OFF:0,FULL:1,ERROR:2}},1863:(e,t,r)=>{"use strict";function n(){return Math.floor(performance.now())}r.d(t,{t:()=>n})},944:(e,t,r)=>{"use strict";function n(e,t){"function"==typeof console.debug&&console.debug("New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/docs/warning-codes.md#".concat(e),t)}r.d(t,{R:()=>n})},5284:(e,t,r)=>{"use strict";r.d(t,{t:()=>c,B:()=>s});var n=r(7836),i=r(6154);const o="newrelic";const a=new Set,s={};function c(e,t){const r=n.ee.get(t);s[t]??={},e&&"object"==typeof e&&(a.has(t)||(r.emit("rumresp",[e]),s[t]=e,a.add(t),function(){let e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:{};try{i.gm.dispatchEvent(new CustomEvent(o,{detail:e}))}catch(e){}}({loaded:!0})))}},8990:(e,t,r)=>{"use strict";r.d(t,{I:()=>i});var n=Object.prototype.hasOwnProperty;function i(e,t,r){if(n.call(e,t))return e[t];var i=r();if(Object.defineProperty&&Object.keys)try{return Object.defineProperty(e,t,{value:i,writable:!0,enumerable:!1}),i}catch(e){}return e[t]=i,i}},6389:(e,t,r)=>{"use strict";function n(e){var t=this;let r=arguments.length>1&&void 0!==arguments[1]?arguments[1]:500,n=arguments.length>2&&void 0!==arguments[2]?arguments[2]:{};const i=n?.leading||!1;let o;return function(){for(var n=arguments.length,a=new Array(n),s=0;s<n;s++)a[s]=arguments[s];i&&void 0===o&&(e.apply(t,a),o=setTimeout((()=>{o=clearTimeout(o)}),r)),i||(clearTimeout(o),o=setTimeout((()=>{e.apply(t,a)}),r))}}function i(e){var t=this;let r=!1;return function(){if(!r){r=!0;for(var n=arguments.length,i=new Array(n),o=0;o<n;o++)i[o]=arguments[o];e.apply(t,i)}}}r.d(t,{J:()=>i,s:()=>n})},5289:(e,t,r)=>{"use strict";r.d(t,{GG:()=>o,sB:()=>a});var n=r(3878);function i(){return"undefined"==typeof document||"complete"===document.readyState}function o(e,t){if(i())return e();(0,n.sp)("load",e,t)}function a(e){if(i())return e();(0,n.DD)("DOMContentLoaded",e)}},384:(e,t,r)=>{"use strict";r.d(t,{NT:()=>o,US:()=>l,Zm:()=>a,bQ:()=>c,dV:()=>s,nY:()=>u,pV:()=>d});var n=r(6154),i=r(1863);const o={beacon:"bam.nr-data.net",errorBeacon:"bam.nr-data.net"};function a(){return n.gm.NREUM||(n.gm.NREUM={}),void 0===n.gm.newrelic&&(n.gm.newrelic=n.gm.NREUM),n.gm.NREUM}function s(){let e=a();return e.o||(e.o={ST:n.gm.setTimeout,SI:n.gm.setImmediate,CT:n.gm.clearTimeout,XHR:n.gm.XMLHttpRequest,REQ:n.gm.Request,EV:n.gm.Event,PR:n.gm.Promise,MO:n.gm.MutationObserver,FETCH:n.gm.fetch}),e}function c(e,t){let r=a();r.initializedAgents??={},t.initializedAt={ms:(0,i.t)(),date:new Date},r.initializedAgents[e]=t}function u(e){let t=a();return t.initializedAgents?.[e]}function l(e,t){a()[e]=t}function d(){return function(){let e=a();const t=e.info||{};e.info={beacon:o.beacon,errorBeacon:o.errorBeacon,...t}}(),function(){let e=a();const t=e.init||{};e.init={...t}}(),s(),function(){let e=a();const t=e.loader_config||{};e.loader_config={...t}}(),a()}},2843:(e,t,r)=>{"use strict";r.d(t,{u:()=>i});var n=r(3878);function i(e){let t=arguments.length>1&&void 0!==arguments[1]&&arguments[1],r=arguments.length>2?arguments[2]:void 0,i=arguments.length>3?arguments[3]:void 0;(0,n.DD)("visibilitychange",(function(){if(t)return void("hidden"===document.visibilityState&&e());e(document.visibilityState)}),r,i)}},3434:(e,t,r)=>{"use strict";r.d(t,{YM:()=>c});var n=r(7836),i=r(5607);const o="nr@original:".concat(i.W);var a=Object.prototype.hasOwnProperty,s=!1;function c(e,t){return e||(e=n.ee),r.inPlace=function(e,t,n,i,o){n||(n="");const a="-"===n.charAt(0);for(let s=0;s<t.length;s++){const c=t[s],u=e[c];l(u)||(e[c]=r(u,a?c+n:n,i,c,o))}},r.flag=o,r;function r(t,r,n,s,c){return l(t)?t:(r||(r=""),nrWrapper[o]=t,function(e,t,r){if(Object.defineProperty&&Object.keys)try{return Object.keys(e).forEach((function(r){Object.defineProperty(t,r,{get:function(){return e[r]},set:function(t){return e[r]=t,t}})})),t}catch(e){u([e],r)}for(var n in e)a.call(e,n)&&(t[n]=e[n])}(t,nrWrapper,e),nrWrapper);function nrWrapper(){var o,a,l,d;try{a=this,o=[...arguments],l="function"==typeof n?n(o,a):n||{}}catch(t){u([t,"",[o,a,s],l],e)}i(r+"start",[o,a,s],l,c);try{return d=t.apply(a,o)}catch(e){throw i(r+"err",[o,a,e],l,c),e}finally{i(r+"end",[o,a,d],l,c)}}}function i(r,n,i,o){if(!s||t){var a=s;s=!0;try{e.emit(r,n,i,t,o)}catch(t){u([t,r,n,i],e)}s=a}}}function u(e,t){t||(t=n.ee);try{t.emit("internal-error",e)}catch(e){}}function l(e){return!(e&&"function"==typeof e&&e.apply&&!e[o])}},993:(e,t,r)=>{"use strict";r.d(t,{ET:()=>o,p_:()=>i});var n=r(860);const i={ERROR:"ERROR",WARN:"WARN",INFO:"INFO",DEBUG:"DEBUG",TRACE:"TRACE"},o="log";n.K.logging},3969:(e,t,r)=>{"use strict";r.d(t,{TZ:()=>n,XG:()=>s,rs:()=>i,xV:()=>a,z_:()=>o});const n=r(860).K.metrics,i="sm",o="cm",a="storeSupportabilityMetrics",s="storeEventMetrics"},6630:(e,t,r)=>{"use strict";r.d(t,{T:()=>n});const n=r(860).K.pageViewEvent},782:(e,t,r)=>{"use strict";r.d(t,{T:()=>n});const n=r(860).K.pageViewTiming},6344:(e,t,r)=>{"use strict";r.d(t,{G4:()=>i});var n=r(2614);r(860).K.sessionReplay;const i={RECORD:"recordReplay",PAUSE:"pauseReplay",REPLAY_RUNNING:"replayRunning",ERROR_DURING_REPLAY:"errorDuringReplay"};n.g.ERROR,n.g.FULL,n.g.OFF},4234:(e,t,r)=>{"use strict";r.d(t,{W:()=>i});var n=r(7836);class i{constructor(e,t,r){this.agentIdentifier=e,this.aggregator=t,this.ee=n.ee.get(e),this.featureName=r,this.blocked=!1}}},2266:(e,t,r)=>{"use strict";r.d(t,{j:()=>k});var n=r(860),i=r(2983),o=r(9908),a=r(7836),s=r(1687),c=r(5289),u=r(6154),l=r(944),d=r(3969),g=r(384),f=r(6344);const h=["setErrorHandler","finished","addToTrace","addRelease","addPageAction","setCurrentRouteName","setPageViewName","setCustomAttribute","interaction","noticeError","setUserId","setApplicationVersion","start",f.G4.RECORD,f.G4.PAUSE,"log","wrapLogger"],p=["setErrorHandler","finished","addToTrace","addRelease"];var v=r(1863),m=r(2614),b=r(993);var y=r(2646),w=r(3434);function A(e,t,r,n){if("object"!=typeof t||!t||"string"!=typeof r||!r||"function"!=typeof t[r])return(0,l.R)(29);const i=function(e){return(e||a.ee).get("logger")}(e),o=(0,w.YM)(i),s=new y.y(a.P);return s.level=n.level,s.customAttributes=n.customAttributes,o.inPlace(t,[r],"wrap-logger-",s),i}function R(){const e=(0,g.pV)();h.forEach((t=>{e[t]=function(){for(var r=arguments.length,n=new Array(r),i=0;i<r;i++)n[i]=arguments[i];return function(t){for(var r=arguments.length,n=new Array(r>1?r-1:0),i=1;i<r;i++)n[i-1]=arguments[i];let o=[];return Object.values(e.initializedAgents).forEach((e=>{e&&e.api?e.exposed&&e.api[t]&&o.push(e.api[t](...n)):(0,l.R)(38,t)})),o.length>1?o:o[0]}(t,...n)}}))}const E={};function x(e,t){let g=arguments.length>2&&void 0!==arguments[2]&&arguments[2];t||(0,s.Ak)(e,"api");const h={};var y=a.ee.get(e),w=y.get("tracer");E[e]=m.g.OFF,y.on(f.G4.REPLAY_RUNNING,(t=>{E[e]=t}));var R="api-",x=R+"ixn-";function _(t,r,n,o){const a=(0,i.Vp)(e);return null===r?delete a.jsAttributes[t]:(0,i.x1)(e,{...a,jsAttributes:{...a.jsAttributes,[t]:r}}),k(R,n,!0,o||null===r?"session":void 0)(t,r)}function N(){}h.log=function(e){let{customAttributes:t={},level:r=b.p_.INFO}=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{};(0,o.p)(d.xV,["API/log/called"],void 0,n.K.metrics,y),function(e,t){let r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:{},i=arguments.length>3&&void 0!==arguments[3]?arguments[3]:b.p_.INFO;(0,o.p)(d.xV,["API/logging/".concat(i.toLowerCase(),"/called")],void 0,n.K.metrics,e),(0,o.p)(b.ET,[(0,v.t)(),t,r,i],void 0,n.K.logging,e)}(y,e,t,r)},h.wrapLogger=function(e,t){let{customAttributes:r={},level:i=b.p_.INFO}=arguments.length>2&&void 0!==arguments[2]?arguments[2]:{};(0,o.p)(d.xV,["API/wrapLogger/called"],void 0,n.K.metrics,y),A(y,e,t,{customAttributes:r,level:i})},p.forEach((e=>{h[e]=k(R,e,!0,"api")})),h.addPageAction=k(R,"addPageAction",!0,n.K.genericEvents),h.setPageViewName=function(t,r){if("string"==typeof t)return"/"!==t.charAt(0)&&(t="/"+t),(0,i.fr)(e).customTransaction=(r||"http://custom.transaction")+t,k(R,"setPageViewName",!0)()},h.setCustomAttribute=function(e,t){let r=arguments.length>2&&void 0!==arguments[2]&&arguments[2];if("string"==typeof e){if(["string","number","boolean"].includes(typeof t)||null===t)return _(e,t,"setCustomAttribute",r);(0,l.R)(40,typeof t)}else(0,l.R)(39,typeof e)},h.setUserId=function(e){if("string"==typeof e||null===e)return _("enduser.id",e,"setUserId",!0);(0,l.R)(41,typeof e)},h.setApplicationVersion=function(e){if("string"==typeof e||null===e)return _("application.version",e,"setApplicationVersion",!1);(0,l.R)(42,typeof e)},h.start=()=>{try{(0,o.p)(d.xV,["API/start/called"],void 0,n.K.metrics,y),y.emit("manual-start-all")}catch(e){(0,l.R)(23,e)}},h[f.G4.RECORD]=function(){(0,o.p)(d.xV,["API/recordReplay/called"],void 0,n.K.metrics,y),(0,o.p)(f.G4.RECORD,[],void 0,n.K.sessionReplay,y)},h[f.G4.PAUSE]=function(){(0,o.p)(d.xV,["API/pauseReplay/called"],void 0,n.K.metrics,y),(0,o.p)(f.G4.PAUSE,[],void 0,n.K.sessionReplay,y)},h.interaction=function(e){return(new N).get("object"==typeof e?e:{})};const T=N.prototype={createTracer:function(e,t){var r={},i=this,a="function"==typeof t;return(0,o.p)(d.xV,["API/createTracer/called"],void 0,n.K.metrics,y),g||(0,o.p)(x+"tracer",[(0,v.t)(),e,r],i,n.K.spa,y),function(){if(w.emit((a?"":"no-")+"fn-start",[(0,v.t)(),i,a],r),a)try{return t.apply(this,arguments)}catch(e){const t="string"==typeof e?new Error(e):e;throw w.emit("fn-err",[arguments,this,t],r),t}finally{w.emit("fn-end",[(0,v.t)()],r)}}}};function k(e,t,r,i){return function(){return(0,o.p)(d.xV,["API/"+t+"/called"],void 0,n.K.metrics,y),i&&(0,o.p)(e+t,[(0,v.t)(),...arguments],r?null:this,i,y),r?void 0:this}}function S(){r.e(296).then(r.bind(r,8778)).then((t=>{let{setAPI:r}=t;r(e),(0,s.Ze)(e,"api")})).catch((e=>{(0,l.R)(27,e),y.abort()}))}return["actionText","setName","setAttribute","save","ignore","onEnd","getContext","end","get"].forEach((e=>{T[e]=k(x,e,void 0,g?n.K.softNav:n.K.spa)})),h.setCurrentRouteName=g?k(x,"routeName",void 0,n.K.softNav):k(R,"routeName",!0,n.K.spa),h.noticeError=function(t,r){"string"==typeof t&&(t=new Error(t)),(0,o.p)(d.xV,["API/noticeError/called"],void 0,n.K.metrics,y),(0,o.p)("err",[t,(0,v.t)(),!1,r,!!E[e]],void 0,n.K.jserrors,y)},u.RI?(0,c.GG)((()=>S()),!0):S(),h}var _=r(5284);const N=e=>{const t=e.startsWith("http");e+="/",r.p=t?e:"https://"+e};let T=!1;function k(e){let t=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{},r=arguments.length>2?arguments[2]:void 0,n=arguments.length>3?arguments[3]:void 0,{init:o,info:s,loader_config:c,runtime:l={},exposed:d=!0}=t;l.loaderType=r;const f=(0,g.pV)();s||(o=f.init,s=f.info,c=f.loader_config),(0,i.xN)(e.agentIdentifier,o||{}),(0,i.aN)(e.agentIdentifier,c||{}),s.jsAttributes??={},u.bv&&(s.jsAttributes.isWorker=!0),(0,i.x1)(e.agentIdentifier,s);const h=(0,i.D0)(e.agentIdentifier),p=[s.beacon,s.errorBeacon];T||(h.proxy.assets&&(N(h.proxy.assets),p.push(h.proxy.assets)),h.proxy.beacon&&p.push(h.proxy.beacon),R(),(0,g.US)("activatedFeatures",_.B),e.runSoftNavOverSpa&&=!0===h.soft_navigations.enabled&&h.feature_flags.includes("soft_nav")),l.denyList=[...h.ajax.deny_list||[],...h.ajax.block_internal?p:[]],l.ptid=e.agentIdentifier,(0,i.V)(e.agentIdentifier,l),e.ee=a.ee.get(e.agentIdentifier),void 0===e.api&&(e.api=x(e.agentIdentifier,n,e.runSoftNavOverSpa)),void 0===e.exposed&&(e.exposed=d),T=!0}},8374:(e,t,r)=>{r.nc=(()=>{try{return document?.currentScript?.nonce}catch(e){}return""})()},860:(e,t,r)=>{"use strict";r.d(t,{K:()=>n,P:()=>i});const n={ajax:"ajax",genericEvents:"generic_events",jserrors:"jserrors",logging:"logging",metrics:"metrics",pageAction:"page_action",pageViewEvent:"page_view_event",pageViewTiming:"page_view_timing",sessionReplay:"session_replay",sessionTrace:"session_trace",softNav:"soft_navigations",spa:"spa"},i={[n.pageViewEvent]:1,[n.pageViewTiming]:2,[n.metrics]:3,[n.jserrors]:4,[n.spa]:5,[n.ajax]:6,[n.sessionTrace]:7,[n.softNav]:8,[n.sessionReplay]:9,[n.logging]:10,[n.genericEvents]:11}}},n={};function i(e){var t=n[e];if(void 0!==t)return t.exports;var o=n[e]={exports:{}};return r[e](o,o.exports,i),o.exports}i.m=r,i.d=(e,t)=>{for(var r in t)i.o(t,r)&&!i.o(e,r)&&Object.defineProperty(e,r,{enumerable:!0,get:t[r]})},i.f={},i.e=e=>Promise.all(Object.keys(i.f).reduce(((t,r)=>(i.f[r](e,t),t)),[])),i.u=e=>"nr-rum-1.264.0.min.js",i.o=(e,t)=>Object.prototype.hasOwnProperty.call(e,t),e={},t="NRBA-1.264.0.PROD:",i.l=(r,n,o,a)=>{if(e[r])e[r].push(n);else{var s,c;if(void 0!==o)for(var u=document.getElementsByTagName("script"),l=0;l<u.length;l++){var d=u[l];if(d.getAttribute("src")==r||d.getAttribute("data-webpack")==t+o){s=d;break}}if(!s){c=!0;var g={296:"sha512-/JFTCbNPZPe6tX1oowGTDXgTXJPZczBrsUMXw4/4Iz7c/U06sSfloejUIdps4/XHjV4Xx4uaRdele2Dq0BHQlw=="};(s=document.createElement("script")).charset="utf-8",s.timeout=120,i.nc&&s.setAttribute("nonce",i.nc),s.setAttribute("data-webpack",t+o),s.src=r,0!==s.src.indexOf(window.location.origin+"/")&&(s.crossOrigin="anonymous"),g[a]&&(s.integrity=g[a])}e[r]=[n];var f=(t,n)=>{s.onerror=s.onload=null,clearTimeout(h);var i=e[r];if(delete e[r],s.parentNode&&s.parentNode.removeChild(s),i&&i.forEach((e=>e(n))),t)return t(n)},h=setTimeout(f.bind(null,void 0,{type:"timeout",target:s}),12e4);s.onerror=f.bind(null,s.onerror),s.onload=f.bind(null,s.onload),c&&document.head.appendChild(s)}},i.r=e=>{"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(e,"__esModule",{value:!0})},i.p="https://js-agent.newrelic.com/",(()=>{var e={840:0,374:0};i.f.j=(t,r)=>{var n=i.o(e,t)?e[t]:void 0;if(0!==n)if(n)r.push(n[2]);else{var o=new Promise(((r,i)=>n=e[t]=[r,i]));r.push(n[2]=o);var a=i.p+i.u(t),s=new Error;i.l(a,(r=>{if(i.o(e,t)&&(0!==(n=e[t])&&(e[t]=void 0),n)){var o=r&&("load"===r.type?"missing":r.type),a=r&&r.target&&r.target.src;s.message="Loading chunk "+t+" failed.\n("+o+": "+a+")",s.name="ChunkLoadError",s.type=o,s.request=a,n[1](s)}}),"chunk-"+t,t)}};var t=(t,r)=>{var n,o,[a,s,c]=r,u=0;if(a.some((t=>0!==e[t]))){for(n in s)i.o(s,n)&&(i.m[n]=s[n]);if(c)c(i)}for(t&&t(r);u<a.length;u++)o=a[u],i.o(e,o)&&e[o]&&e[o][0](),e[o]=0},r=self["webpackChunk:NRBA-1.264.0.PROD"]=self["webpackChunk:NRBA-1.264.0.PROD"]||[];r.forEach(t.bind(null,0)),r.push=t.bind(null,r.push.bind(r))})(),(()=>{"use strict";i(8374);var e=i(944),t=i(6344),r=i(9566);class n{agentIdentifier;constructor(){let e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:(0,r.LA)(16);this.agentIdentifier=e}#e(t){for(var r=arguments.length,n=new Array(r>1?r-1:0),i=1;i<r;i++)n[i-1]=arguments[i];if("function"==typeof this.api?.[t])return this.api[t](...n);(0,e.R)(35,t)}addPageAction(e,t){return this.#e("addPageAction",e,t)}setPageViewName(e,t){return this.#e("setPageViewName",e,t)}setCustomAttribute(e,t,r){return this.#e("setCustomAttribute",e,t,r)}noticeError(e,t){return this.#e("noticeError",e,t)}setUserId(e){return this.#e("setUserId",e)}setApplicationVersion(e){return this.#e("setApplicationVersion",e)}setErrorHandler(e){return this.#e("setErrorHandler",e)}finished(e){return this.#e("finished",e)}addRelease(e,t){return this.#e("addRelease",e,t)}start(e){return this.#e("start",e)}recordReplay(){return this.#e(t.G4.RECORD)}pauseReplay(){return this.#e(t.G4.PAUSE)}addToTrace(e){return this.#e("addToTrace",e)}setCurrentRouteName(e){return this.#e("setCurrentRouteName",e)}interaction(){return this.#e("interaction")}log(e,t){return this.#e("logInfo",e,t)}wrapLogger(e,t,r){return this.#e("wrapLogger",e,t,r)}}var o=i(860),a=i(2983);const s=Object.values(o.K);function c(e){const t={};return s.forEach((r=>{t[r]=function(e,t){return!0===(0,a.gD)(t,"".concat(e,".enabled"))}(r,e)})),t}var u=i(2266);var l=i(1687),d=i(4234),g=i(5289),f=i(6154);const h=e=>f.RI&&!0===(0,a.gD)(e,"privacy.cookies_enabled");function p(e){return!!a.hR.MO&&h(e)&&!0===(0,a.gD)(e,"session_trace.enabled")}var v=i(6389);class m extends d.W{constructor(e,t,r){let n=!(arguments.length>3&&void 0!==arguments[3])||arguments[3];super(e,t,r),this.auto=n,this.abortHandler=void 0,this.featAggregate=void 0,this.onAggregateImported=void 0,!1===(0,a.gD)(this.agentIdentifier,"".concat(this.featureName,".autoStart"))&&(this.auto=!1),this.auto?(0,l.Ak)(e,r):this.ee.on("manual-start-all",(0,v.J)((()=>{(0,l.Ak)(this.agentIdentifier,this.featureName),this.auto=!0,this.importAggregator()})))}importAggregator(){let t,r=arguments.length>0&&void 0!==arguments[0]?arguments[0]:{};if(this.featAggregate||!this.auto)return;this.onAggregateImported=new Promise((e=>{t=e}));const n=async()=>{let n;try{if(h(this.agentIdentifier)){const{setupAgentSession:e}=await i.e(296).then(i.bind(i,2987));n=e(this.agentIdentifier)}}catch(t){(0,e.R)(20,t),this.ee.emit("internal-error",[t]),this.featureName===o.K.sessionReplay&&this.abortHandler?.()}try{if(!this.#t(this.featureName,n))return(0,l.Ze)(this.agentIdentifier,this.featureName),void t(!1);const{lazyFeatureLoader:e}=await i.e(296).then(i.bind(i,6103)),{Aggregate:o}=await e(this.featureName,"aggregate");this.featAggregate=new o(this.agentIdentifier,this.aggregator,r),t(!0)}catch(r){(0,e.R)(34,r),this.abortHandler?.(),(0,l.Ze)(this.agentIdentifier,this.featureName,!0),t(!1),this.ee&&this.ee.abort()}};f.RI?(0,g.GG)((()=>n()),!0):n()}#t(e,t){switch(e){case o.K.sessionReplay:return p(this.agentIdentifier)&&!!t;case o.K.sessionTrace:return!!t;default:return!0}}}var b=i(6630);class y extends m{static featureName=(()=>b.T)();constructor(e,t){let r=!(arguments.length>2&&void 0!==arguments[2])||arguments[2];super(e,t,b.T,r),this.importAggregator()}}var w=i(4777);class A extends w.J{constructor(e){super(e),this.aggregatedData={}}store(e,t,r,n,i){var o=this.getBucket(e,t,r,i);return o.metrics=function(e,t){t||(t={count:0});return t.count+=1,Object.entries(e||{}).forEach((e=>{let[r,n]=e;t[r]=R(n,t[r])})),t}(n,o.metrics),o}merge(e,t,r,n,i){var o=this.getBucket(e,t,n,i);if(o.metrics){var a=o.metrics;a.count+=r.count,Object.keys(r||{}).forEach((e=>{if("count"!==e){var t=a[e],n=r[e];n&&!n.c?a[e]=R(n.t,t):a[e]=function(e,t){if(!t)return e;t.c||(t=E(t.t));return t.min=Math.min(e.min,t.min),t.max=Math.max(e.max,t.max),t.t+=e.t,t.sos+=e.sos,t.c+=e.c,t}(n,a[e])}}))}else o.metrics=r}storeMetric(e,t,r,n){var i=this.getBucket(e,t,r);return i.stats=R(n,i.stats),i}getBucket(e,t,r,n){this.aggregatedData[e]||(this.aggregatedData[e]={});var i=this.aggregatedData[e][t];return i||(i=this.aggregatedData[e][t]={params:r||{}},n&&(i.custom=n)),i}get(e,t){return t?this.aggregatedData[e]&&this.aggregatedData[e][t]:this.aggregatedData[e]}take(e){for(var t={},r="",n=!1,i=0;i<e.length;i++)t[r=e[i]]=Object.values(this.aggregatedData[r]||{}),t[r].length&&(n=!0),delete this.aggregatedData[r];return n?t:null}}function R(e,t){return null==e?function(e){e?e.c++:e={c:1};return e}(t):t?(t.c||(t=E(t.t)),t.c+=1,t.t+=e,t.sos+=e*e,e>t.max&&(t.max=e),e<t.min&&(t.min=e),t):{t:e}}function E(e){return{t:e,min:e,max:e,sos:e*e,c:1}}var x=i(384);var _=i(9908),N=i(2843),T=i(3878),k=i(782),S=i(1863);class j extends m{static featureName=(()=>k.T)();constructor(e,t){let r=!(arguments.length>2&&void 0!==arguments[2])||arguments[2];super(e,t,k.T,r),f.RI&&((0,N.u)((()=>(0,_.p)("docHidden",[(0,S.t)()],void 0,k.T,this.ee)),!0),(0,T.sp)("pagehide",(()=>(0,_.p)("winPagehide",[(0,S.t)()],void 0,k.T,this.ee))),this.importAggregator())}}var I=i(3969);class O extends m{static featureName=(()=>I.TZ)();constructor(e,t){let r=!(arguments.length>2&&void 0!==arguments[2])||arguments[2];super(e,t,I.TZ,r),this.importAggregator()}}new class extends n{constructor(t,r){super(r),f.gm?(this.sharedAggregator=new A({agentIdentifier:this.agentIdentifier}),this.features={},(0,x.bQ)(this.agentIdentifier,this),this.desiredFeatures=new Set(t.features||[]),this.desiredFeatures.add(y),this.runSoftNavOverSpa=[...this.desiredFeatures].some((e=>e.featureName===o.K.softNav)),(0,u.j)(this,t,t.loaderType||"agent"),this.run()):(0,e.R)(21)}get config(){return{info:this.info,init:this.init,loader_config:this.loader_config,runtime:this.runtime}}run(){try{const t=c(this.agentIdentifier),r=[...this.desiredFeatures];r.sort(((e,t)=>o.P[e.featureName]-o.P[t.featureName])),r.forEach((r=>{if(!t[r.featureName]&&r.featureName!==o.K.pageViewEvent)return;if(this.runSoftNavOverSpa&&r.featureName===o.K.spa)return;if(!this.runSoftNavOverSpa&&r.featureName===o.K.softNav)return;(function(e){switch(e){case o.K.ajax:return[o.K.jserrors];case o.K.sessionTrace:return[o.K.ajax,o.K.pageViewEvent];case o.K.sessionReplay:return[o.K.sessionTrace];case o.K.pageViewTiming:return[o.K.pageViewEvent];default:return[]}})(r.featureName).every((e=>e in this.features))||(0,e.R)(36,r.featureName),this.features[r.featureName]=new r(this.agentIdentifier,this.sharedAggregator)}))}catch(t){(0,e.R)(22,t);for(const e in this.features)this.features[e].abortHandler?.();const r=(0,x.Zm)();delete r.initializedAgents[this.agentIdentifier]?.api,delete r.initializedAgents[this.agentIdentifier]?.features,delete this.sharedAggregator;return r.ee.get(this.agentIdentifier).abort(),!1}}}({features:[y,j,O],loaderType:"lite"})})()})();</script>
+<link rel="canonical" href="https://www.pitt.edu/pittwire/news/features-articles" />
+<meta property="og:site_name" content="University of Pittsburgh" />
+<meta property="og:type" content="website" />
+<meta property="og:url" content="https://www.pitt.edu/pittwire/news/features-articles" />
+<meta property="og:title" content="Pittwire News" />
+<meta name="MobileOptimized" content="width" />
+<meta name="HandheldFriendly" content="true" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<script type="application/ld+json">{
+    "@context": "https://schema.org",
+    "@graph": [
+        {
+            "@type": "Organization",
+            "@id": "https://www.pitt.edu/",
+            "name": "University of Pittsburgh",
+            "url": "https://www.pitt.edu/"
+        }
+    ]
+}</script>
+<link rel="icon" href="/sites/default/files/favicon.ico" type="image/vnd.microsoft.icon" />
+
+    <title>Pittwire News | University of Pittsburgh</title>
+    <link rel="stylesheet" media="all" href="/core/modules/system/css/components/ajax-progress.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/align.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/autocomplete-loading.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/fieldgroup.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/container-inline.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/clearfix.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/details.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/hidden.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/item-list.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/js.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/nowrap.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/position-container.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/progress.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/reset-appearance.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/resize.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/sticky-header.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/system-status-counter.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/system-status-report-counters.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/system-status-report-general-info.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/tabledrag.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/tablesort.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/tree-child.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/media/css/oembed.formatter.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/views/css/views.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/sites/default/files/micon/fa/style.css?shklz9" />
+<link rel="stylesheet" media="all" href="/modules/contrib/social_media_links/css/social_media_links.theme.css?shklz9" />
+<link rel="stylesheet" media="all" href="/modules/contrib/extlink/extlink.css?shklz9" />
+<link rel="stylesheet" media="all" href="/modules/contrib/paragraphs/css/paragraphs.unpublished.css?shklz9" />
+<link rel="stylesheet" media="all" href="/modules/contrib/better_exposed_filters/css/better_exposed_filters.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/global-styles.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/navigation.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/hero-banner.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/content-well.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/template-layout-mixin.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/collapse.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/footer-override.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/button.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/breadcrumb.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/cse.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/overrides.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/pittmag.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/contrib/zensource_front_end/css/components/hero-placeholder.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/contrib/zensource_front_end/css/classy/components/messages.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/contrib/zensource_front_end/css/classy/components/details.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/contrib/zenny/css/classy/components/pager.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/card.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/contrib/zensource_front_end/css/components/entity-overlay.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/media-item.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/choices.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/form.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/modal.css?shklz9" />
+
+
+	<!-- Google Tag Manager -->
+	<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+	new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+	j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+	'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+	})(window,document,'script','dataLayer','GTM-NXCGL72');</script>
+	<!-- End Google Tag Manager -->
+
+  <script async src="https://cse.google.com/cse.js?cx=013753980878518964357:mgrjnoukllc"></script>
+
+  </head>
+  <body class="path-pittwire">
+	<!-- Google Tag Manager (noscript) -->
+	<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NXCGL72"
+	height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+	<!-- End Google Tag Manager (noscript) -->
+
+        <a href="#main-content" class="visually-hidden focusable skip-link">
+      Skip to main content
+    </a>
+
+      <div class="dialog-off-canvas-main-canvas" data-off-canvas-main-canvas>
+
+
+        <div id="block-pitt-pittwire-sitebranding" class="block block-system block-system-branding-block">
+
+
+  <!-- global nav -->
+<div class="header-wrapper" role="region" aria-label="Navigation area">
+<header class="header pitt-wire">
+  <div class="header-container">
+    <div class="header-grid">
+      <div class="pitt-wire-nav">
+        <div class="logo">
+                      <div class="logo-pitt"><a href="/"><img src="/themes/custom/pitt_pittwire/logo.svg" alt="University of Pittsburgh"></a></div>
+            <div class="logo-pitt print-only"><img src="/themes/custom/pitt_pittwire/logo-print.png" alt="UPitt Logo"></div>
+                    <div class="logo-pitt-wire"><a href="/pittwire"><img src="/themes/custom/pitt_pittwire/logo-pittwire.svg" alt="Pitt Wire"></a></div>
+          <div class="logo-pitt-wire print-only"><img src="/themes/custom/pitt_pittwire/logo-pittwire-print.png" alt="Pitt Wire"></div>
+        </div>
+        <div class="explore-sections"><button class="" data-toggle="modal" data-target="#pitt-wire-menu" data-gtm="">Explore Sections</button></div>
+      </div>
+      <!-- main navigation -->
+      <div class="navigation" role="navigation" aria-label="Mega Menu">
+        <ul class="navigation-button-wrapper">
+          <li>
+            <button type="button" class="navigation-button" data-toggle="modal" data-target="#pittwire-search-menu" data-gtm="">
+              <span class="sr-only">open search</span>
+              <span class="icon-search"></span>
+            </button>
+          </li>
+          <li>
+            <button type="button" class="navigation-button" data-toggle="modal" data-target="#hamburger-menu" data-gtm="">
+              <span class="sr-only">open menu</span>
+              <span class="icon-hamburger"></span>
+            </button>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</header>
+</div>
+</div>
+
+
+<div id="pitt-wire-menu" class="modal modal--side navigation-slide-menu left pitt-wire-menu" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <!-- modal - header -->
+      <div class="modal-header">
+        <!-- modal - dismiss -->
+        <button type="button" class="modal-dismiss-button" data-dismiss="modal" aria-label="Close" data-gtm="">
+          <span class="sr-only">Close</span>
+        </button>
+      </div>
+      <!-- modal - body -->
+      <div class="modal-body">
+               	        <p class="field field--type-string-long field--label-hidden field__item">
+	  	  From the latest big breakthrough to the most influential and inspiring figures on campus to Pitt in the community, Pittwire is your official source for what’s happening now.
+	  	  </p>
+
+        <div class="hamburger-menu-wrapper">
+          <div class="hamburger-menu-upper">
+            <div id="block-pittwireexploretopics" class="hamburger-menu-upper-column block block-menu menu--pittwire-explore-topics">
+    <div class="hamburger-menu-header">Explore Sections</div>
+
+
+
+                <ul class="hamburger-menu-list">
+                    <li>
+                <a href="/pittwire/health-and-wellness" data-drupal-link-system-path="node/21">Health and Wellness</a>
+            </li>
+                    <li>
+                <a href="/pittwire/technology-and-science" data-drupal-link-system-path="node/13546">Technology and Science</a>
+            </li>
+                    <li>
+                <a href="/pittwire/arts-and-humanities" data-drupal-link-system-path="node/13547">Arts and Humanities</a>
+            </li>
+                    <li>
+                <a href="/pittwire/community-impact" data-drupal-link-system-path="node/13548">Community Impact</a>
+            </li>
+                    <li>
+                <a href="/pittwire/diversity-equity-and-inclusion" data-drupal-link-system-path="node/13551">Diversity, Equity, and Inclusion</a>
+            </li>
+                    <li>
+                <a href="/pittwire/global" data-drupal-link-system-path="node/13550">Global</a>
+            </li>
+                    <li>
+                <a href="/pittwire/innovation-and-research" data-drupal-link-system-path="node/13549">Innovation and Research</a>
+            </li>
+                    <li>
+                <a href="/pittwire/our-cityour-campus" data-drupal-link-system-path="node/13552">Our City/Our Campus</a>
+            </li>
+                    <li>
+                <a href="/pittwire/pittmagazine" data-drupal-link-system-path="pittwire/pittmagazine">Pitt Magazine</a>
+            </li>
+                </ul>
+
+
+
+    </div>
+            <div class="views-element-container hamburger-menu-upper-column block block-views block-views-blockcategory-menu-category-menu" id="block-views-block-category-menu-category-menu">
+            <div class="hamburger-menu-header">Explore By Category</div>
+                <div><div class="view view-category-menu view-id-category_menu view-display-id-category_menu js-view-dom-id-b170f5273de9e49d338bd391911f15a452a1aad3165e79a0130dcec5844e7ea5">
+
+
+
+      <div class="view-content">
+      <ul class="hamburger-menu-list">
+            <li><div class="views-field views-field-name"><span class="field-content"><a href="/pittwire/news/features-articles">Features &amp; Articles</a></span></div></li>
+            <li><div class="views-field views-field-name"><span class="field-content"><a href="/pittwire/news/accolades-honors">Accolades &amp; Honors</a></span></div></li>
+            <li><div class="views-field views-field-name"><span class="field-content"><a href="/pittwire/news/ones-to-watch">Ones to Watch</a></span></div></li>
+            <li><div class="views-field views-field-name"><span class="field-content"><a href="/pittwire/news/announcements-and-updates">Announcements and Updates</a></span></div></li>
+    </ul>
+
+    </div>
+
+          </div>
+</div>
+
+
+    <nav role="navigation" aria-labelledby="block-pittwireotherlinks-menu" id="block-pittwireotherlinks" class="block block-menu navigation menu--pittwire-other-links">
+
+  <h2 class="visually-hidden" id="block-pittwireotherlinks-menu">Pittwire Other Links</h2>
+
+
+
+<ul class="hamburger-menu-main">
+            <li>
+            <a href="https://calendar.pitt.edu/" target="_blank">Event Calendar</a>
+        </li>
+            <li>
+            <a href="https://www.pitt.edu/social" target="_blank">Social Media Directory</a>
+        </li>
+    </ul>
+
+
+
+  </nav>
+
+</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="search-menu" class="modal modal--side navigation-slide-menu right" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <!-- modal - header -->
+      <div class="modal-header">
+        <!-- modal - dismiss -->
+        <button type="button" class="modal-dismiss-button" data-dismiss="modal" aria-label="Close" data-gtm="">
+          <span class="sr-only">Close</span>
+        </button>
+      </div>
+      <!-- modal - body -->
+      <div class="modal-body">
+        <div class="search-menu-wrapper">
+          <div class="search-menu-header">Search Pitt</div>
+
+          <div class="search-menu-typeahead-wrapper">
+            <div class="search-menu-typeahead">
+              <label for="main-search-nav" class="sr-only">Search</label>
+
+              <!-- cse markup -->
+              <div class="gcse-searchbox-only" data-enableHistory="true" data-autoCompleteMaxCompletions="5" data-autoCompleteMatchType="any" data-resultsUrl="search-results"></div>
+
+            </div>
+
+          </div>
+
+
+          <div class="search-menu-footer">
+            <a href="https://find.pitt.edu" class="arrow">Search for People</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<div id="hamburger-menu" class="modal modal--side navigation-slide-menu right" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <!-- modal - header -->
+      <div class="modal-header">
+        <!-- modal - dismiss -->
+        <button type="button" class="modal-dismiss-button" data-dismiss="modal" aria-label="Close" data-gtm="">
+          <span class="sr-only">Close</span>
+        </button>
+      </div>
+      <!-- modal - body -->
+      <div class="modal-body">
+        <div class="hamburger-menu-wrapper">
+                      <div id="block-hamburgermenuupper-2" class="hamburger-menu-upper block block-blockgroup block-block-grouphamburger-menu-upper">
+
+
+      <div id="block-hamburgermenuuppercolumn1" class="hamburger-menu-upper-column block block-blockgroup block-block-grouphamburger-menu-upper-column-1">
+
+
+      <nav role="navigation" aria-labelledby="block-globalmenu-3-menu" id="block-globalmenu-3" class="block block-menu navigation menu--global-menu">
+
+  <h2 class="visually-hidden" id="block-globalmenu-3-menu">Global Menu</h2>
+
+
+
+        <ul class="hamburger-menu-main">
+          <li>
+	  <a href="https://admissions.pitt.edu/apply/" class="data-gtm-utilityNavKPI" data-contentTitle="Apply">Apply</a>
+      </li>
+          <li>
+	  <a href="https://admissions.pitt.edu/visit/unscripted/" class="data-gtm-utilityNavKPI" data-contentTitle="Visit">Visit</a>
+      </li>
+          <li>
+	  <a href="https://www.giveto.pitt.edu/s/1729/18/home-giving.aspx?gid=2&amp;pgid=2135" class="data-gtm-utilityNavKPI" data-contentTitle="Give">Give</a>
+      </li>
+          <li>
+	  <a href="/pittwire" class="data-gtm-utilityNavKPI" data-contentTitle="Pittwire">Pittwire</a>
+      </li>
+          <li>
+	  <a href="http://calendar.pitt.edu/" class="data-gtm-utilityNavKPI" data-contentTitle="Events">Events</a>
+      </li>
+        </ul>
+
+
+
+  </nav>
+      <button is="menu-blockmain-btn" class="collapse-trigger--md collapsed hamburger-menu-header-btn" role="tab" data-toggle="collapse" data-target="#menu-blockmain" aria-expanded="false" aria-controls="menu-blockmain" data-gtm="">Navigation</button>
+<div class="collapse-target--md collapse" id="menu-blockmain" role="tabpanel" aria-labelledby="menu-blockmain-btn">
+
+
+  <div  id="block-navigation-2-menu" class="hamburger-menu-header">Navigation</div>
+
+
+
+        <ul class="hamburger-menu-list">
+          <li>
+		<a href="/about" class="data-gtm-utilityNavCategory" data-contentTitle="About">About</a>
+      </li>
+          <li>
+		<a href="/academics" class="data-gtm-utilityNavCategory" data-contentTitle="Academics">Academics</a>
+      </li>
+          <li>
+		<a href="/admissions" class="data-gtm-utilityNavCategory" data-contentTitle="Admissions">Admissions</a>
+      </li>
+          <li>
+		<a href="/research" class="data-gtm-utilityNavCategory" data-contentTitle="Research">Research</a>
+      </li>
+          <li>
+		<a href="/student-life" class="data-gtm-utilityNavCategory" data-contentTitle="Life at Pitt">Life at Pitt</a>
+      </li>
+          <li>
+		<a href="http://pittsburghpanthers.com/" class="data-gtm-utilityNavCategory" data-contentTitle="Athletics">Athletics</a>
+      </li>
+        </ul>
+
+
+
+  </div>
+
+  </div>
+<div id="block-hamburgermenuuppercolumn2" class="hamburger-menu-upper-column block block-blockgroup block-block-grouphamburger-menu-upper-">
+
+
+            <button is="menu-blockquick-links-3-btn" class="collapse-trigger--md collapsed hamburger-menu-header-btn" role="tab" data-toggle="collapse" data-target="#menu-blockquick-links-3" aria-expanded="false" aria-controls="menu-blockquick-links-3" data-gtm="">Colleges &amp; Schools</button>
+<div class="collapse-target--md collapse" id="menu-blockquick-links-3" role="tabpanel" aria-labelledby="menu-blockquick-links-3-btn">
+
+
+  <div  id="block-collegesschools-2-menu" class="hamburger-menu-header">Colleges &amp; Schools</div>
+
+
+
+        <ul class="hamburger-menu-list">
+          <li>
+		<a href="https://www.as.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Arts &amp; Sciences">Arts &amp; Sciences</a>
+      </li>
+          <li>
+		<a href="https://www.business.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Business">Business</a>
+      </li>
+          <li>
+		<a href="https://www.sci.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Computing &amp; Information">Computing &amp; Information</a>
+      </li>
+          <li>
+		<a href="https://www.dental.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Dental Medicine">Dental Medicine</a>
+      </li>
+          <li>
+		<a href="https://www.education.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Education">Education</a>
+      </li>
+          <li>
+		<a href="https://www.engineering.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Engineering">Engineering</a>
+      </li>
+          <li>
+		<a href="https://www.cgs.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="General Studies">General Studies</a>
+      </li>
+          <li>
+		<a href="https://www.shrs.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Health &amp; Rehabilitation">Health &amp; Rehabilitation</a>
+      </li>
+          <li>
+		<a href="https://www.honors.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Honors College">Honors College</a>
+      </li>
+          <li>
+		<a href="https://www.law.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Law">Law</a>
+      </li>
+          <li>
+		<a href="https://www.medschool.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Medicine">Medicine</a>
+      </li>
+          <li>
+		<a href="https://www.nursing.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Nursing">Nursing</a>
+      </li>
+          <li>
+		<a href="https://www.pharmacy.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Pharmacy">Pharmacy</a>
+      </li>
+          <li>
+		<a href="https://www.gspia.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Public &amp; Intl Affairs">Public &amp; Intl Affairs</a>
+      </li>
+          <li>
+		<a href="https://publichealth.pitt.edu/" class="data-gtm-utilityNavCategory" data-contentTitle="Public Health">Public Health</a>
+      </li>
+          <li>
+		<a href="https://www.socialwork.pitt.edu/" class="data-gtm-utilityNavCategory" data-contentTitle="Social Work">Social Work</a>
+      </li>
+        </ul>
+
+
+
+  </div>
+
+  </div>
+
+  </div>
+<div id="block-hamburgermenulower" class="hamburger-menu-lower block block-blockgroup block-block-grouphamburger-menu-lower">
+
+
+      <div id="block-hamburgermenulowercolumn1" class="hamburger-menu-lower-column block block-blockgroup block-block-grouphamburger-menu-lower-column-1">
+
+
+            <button is="menu-blockinfo-menu-btn" class="collapse-trigger--md collapsed hamburger-menu-header-btn" role="tab" data-toggle="collapse" data-target="#menu-blockinfo-menu" aria-expanded="false" aria-controls="menu-blockinfo-menu" data-gtm="">Info For</button>
+<div class="collapse-target--md collapse" id="menu-blockinfo-menu" role="tabpanel" aria-labelledby="menu-blockinfo-menu-btn">
+
+
+  <div  id="block-infomenu-2-menu" class="hamburger-menu-header">Info For</div>
+
+
+
+            <ul class="hamburger-menu-list">
+      <li class="hamburger-menu-list-wrapper">
+        <ul class="hamburger-menu-list">
+                              <li>
+			<a href="http://coronavirus.pitt.edu/" class="data-gtm-utilityNavCategory" data-contentTitle="COVID-19 Response">COVID-19 Response</a>
+            </li>
+                                        <li>
+			<a href="https://www.alumni.pitt.edu/s/1729/alumni/home.aspx?gid=2&amp;pgid=2381" class="data-gtm-utilityNavCategory" data-contentTitle="Alumni">Alumni</a>
+            </li>
+                                                                                </ul>
+        <ul class="hamburger-menu-list">
+                                                                  <li>
+			<a href="https://www.community.pitt.edu/" class="data-gtm-utilityNavCategory" data-contentTitle="Community">Community</a>
+            </li>
+                                        <li>
+			<a href="/global" class="data-gtm-utilityNavCategory" data-contentTitle="Global">Global</a>
+            </li>
+                                        <li>
+			<a href="https://www.sustainable.pitt.edu/" class="data-gtm-utilityNavCategory" data-contentTitle="Sustainability">Sustainability</a>
+            </li>
+                          </ul>
+      </li>
+    </ul>
+
+
+
+
+  </div>
+
+  </div>
+<div id="block-hamburgermenulowercolumn2" class="hamburger-menu-lower-column block block-blockgroup block-block-grouphamburger-menu-lower-column-2">
+
+
+      <div id="block-socialmedialinks-4" class="hamburger-menu-social block-social-media-links block block-social-media-links-block">
+
+
+
+
+<ul class="social-media-links--platforms platforms inline horizontal">
+      <li>
+      <a class="social-media-link-icon--twitter" href="https://www.twitter.com/PittTweet"  >
+          <i class="micon fa-twitter" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Twitter</span>
+      </a>
+    </li>
+      <li>
+      <a class="social-media-link-icon--instagram" href="https://www.instagram.com/pittofficial"  >
+          <i class="micon fa-instagram" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Instagram</span>
+      </a>
+    </li>
+      <li>
+      <a class="social-media-link-icon--facebook" href="https://www.facebook.com/upitt"  >
+          <i class="micon fa-facebook" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Facebook</span>
+      </a>
+    </li>
+      <li>
+      <a class="social-media-link-icon--youtube" href="https://www.youtube.com/user/pittweb"  >
+          <i class="micon fa-youtube" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Youtube</span>
+      </a>
+    </li>
+  </ul>
+
+  </div>
+
+  </div>
+
+  </div>
+
+                  </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="pittwire-search-menu" class="modal modal--side navigation-slide-menu right" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <!-- modal - header -->
+      <div class="modal-header">
+        <!-- modal - dismiss -->
+        <button type="button" class="modal-dismiss-button" data-dismiss="modal" aria-label="Close" data-gtm="">
+          <span class="sr-only">Close</span>
+        </button>
+      </div>
+      <!-- modal - body -->
+      <div class="modal-body">
+        <div class="search-menu-wrapper">
+          <div class="search-menu-header">Search Pittwire</div>
+
+          <div class="search-menu-typeahead-wrapper">
+            <div class="search-menu-typeahead">
+              <label for="main-search-nav" class="sr-only">Search</label>
+
+              <!-- cse markup -->
+              <div class="gcse-searchbox-only" data-enableHistory="true" data-autoCompleteMaxCompletions="5" data-autoCompleteMatchType="any" data-resultsUrl="/pittwire/search-results"></div>
+
+            </div>
+
+          </div>
+
+
+          <div class="search-menu-footer">
+            <a href="https://www.pitt.edu/search-results" class="arrow">Search www.pitt.edu</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+<main id="content" class="main-container">
+    <a id="main-content" tabindex="-1"></a>
+    <div class="layout--right-rail pittwire">
+
+        <section class="main-content">
+              <div class="region region-content">
+    <div id="block-pitt-pittwire-mainpagecontent" class="block block-system block-system-main-block">
+
+
+      <div class="views-element-container">
+<div class="view view-article-view view-id-article_view view-display-id-pittwire_news js-view-dom-id-392f352e28489a709c2c666eb3fa2514d3dee5cf806801f8862e98f2f718e4c5">
+            <div class="page-header">
+            <div class="page-header-container">
+                                    <h1 class="page-header-title">Features &amp; Articles
+</h1>
+                            </div>
+        </div>
+                <div class="filter-module">
+            <div class="filter-container">
+                <div class="filter-wrapper">
+                    <h2 class="filter-wrapper-title">Filter By</h2>
+                    <form class="views-exposed-form bef-exposed-form" data-bef-auto-submit-full-form="" data-bef-auto-submit="" data-bef-auto-submit-delay="1000" novalidate="novalidate" data-drupal-selector="views-exposed-form-article-view-pittwire-news" action="/pittwire/news/features-articles" method="get" id="views-exposed-form-article-view-pittwire-news" accept-charset="UTF-8">
+  <div class="filter-grid">
+
+  <fieldset class="js-form-item js-form-type-select form-type-select js-form-item-field-topics-target-id form-item-field-topics-target-id form-group">
+          <label for="edit-field-topics-target-id">Search by topic</label>
+                <select data-drupal-selector="edit-field-topics-target-id" id="edit-field-topics-target-id" name="field_topics_target_id" class="form-select form-control"><option value="All">Topics</option><option value="432" selected="selected">University News</option><option value="2">Health and Wellness</option><option value="391">Technology &amp; Science</option><option value="4">Arts and Humanities</option><option value="6">Community Impact</option><option value="1">Innovation and Research</option><option value="9">Global</option><option value="8">Diversity, Equity, and Inclusion</option><option value="12">Our City/Our Campus</option><option value="7">Teaching &amp; Learning</option><option value="440">Space</option><option value="441">Ukraine</option><option value="470">Sustainability</option></select>
+                  </fieldset>
+
+  <fieldset class="js-form-item js-form-type-select form-type-select js-form-item-field-article-date-value form-item-field-article-date-value form-group">
+          <label for="edit-field-article-date-value">Search by date</label>
+                <select data-drupal-selector="edit-field-article-date-value" id="edit-field-article-date-value" name="field_article_date_value" class="form-select form-control"><option value="" selected="selected">Year</option><option value="2012">2012</option><option value="2015">2015</option><option value="2016">2016</option><option value="2017">2017</option><option value="2018">2018</option><option value="2019">2019</option><option value="2020">2020</option><option value="2021">2021</option><option value="2022">2022</option><option value="2023">2023</option><option value="2024">2024</option></select>
+                  </fieldset>
+
+  <fieldset class="form-title-search js-form-item js-form-type-textfield form-type-textfield js-form-item-title form-item-title form-no-label form-group">
+          <label for="edit-title" class="sr-only">Search News</label>
+                <input placeholder="Search News" data-bef-auto-submit-exclude="" data-drupal-selector="edit-title" type="text" id="edit-title" name="title" value="fulbright" size="30" maxlength="128" class="form-text form-control" />
+
+                  </fieldset>
+<input data-drupal-selector="edit-field-category-target-id" type="hidden" name="field_category_target_id" value="All" class="form-control" />
+<div data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-group" id="edit-actions"><input data-bef-auto-submit-click="" data-drupal-selector="edit-submit-article-view" type="submit" id="edit-submit-article-view" value="Apply" class="button js-form-submit form-submit btn btn-primary form-control" />
+</div>
+
+    <button type="button" class="filter-search-btn"><span class="icon-search"></span> <span class="sr-only">Search News</span></button>
+</div>
+
+</form>
+
+                </div>
+            </div>
+        </div>
+
+            <div class="listing-wrapper">
+            <div class="listing-container">
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/faculty-fulbright-scholars-2024">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-04/20190828_ta_globalhubstock_0045_hero.jpg?h=de836872&amp;itok=GHdDqxVQ" alt="Blue and yellow dots on a world map" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/faculty-fulbright-scholars-2024">      	  	  Meet Pitt’s 2024 faculty Fulbright winners
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  The Fulbright U.S. Scholar Program offers faculty the opportunity to teach and conduct research abroad.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Innovation and Research
+				</li>
+		      		        <li class="field__item">
+				Global
+				</li>
+		      		        <li class="field__item">
+				Faculty
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/2023-24-pitt-fulbright-winners">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2023-05/20230208_commons-room_0001_hero.jpg?h=de836872&amp;itok=JlBibWqe" alt="the Cathedral of Learning commons room" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/2023-24-pitt-fulbright-winners">      	  	  10 Pitt students and alums are 2023-24 Fulbright winners
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  The announcement comes a year after the University was named a top producer of U.S. recipients in 2022-23.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Global
+				</li>
+		      		        <li class="field__item">
+				Alumni
+				</li>
+		      		        <li class="field__item">
+				Students
+				</li>
+		      		        <li class="field__item">
+				University Center for International Studies (UCIS)
+				</li>
+		      		        <li class="field__item">
+				David C. Frederick Honors College
+				</li>
+		      		        <li class="field__item">
+				Kenneth P. Dietrich School of Arts and Sciences
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/pitt-fulbright-top-producing-institution-2022-2023">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2023-02/20210407_ta_cl-drone_0141_hero.jpg?h=de836872&amp;itok=ltrmsbnZ" alt="The Cathedral of Learning with Oakland in the background" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/pitt-fulbright-top-producing-institution-2022-2023">      	  	  Pitt has been named a top producer of Fulbright U.S. students for 2022-23
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  Meet the nine Pitt scholars in this year’s cohort.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Global
+				</li>
+		      		        <li class="field__item">
+				David C. Frederick Honors College
+				</li>
+		      		        <li class="field__item">
+				Kenneth P. Dietrich School of Arts and Sciences
+				</li>
+		      		        <li class="field__item">
+				School of Education
+				</li>
+		      		        <li class="field__item">
+				Swanson School of Engineering
+				</li>
+		      	    </ul>
+
+</div>
+
+            </div>
+        </div>
+
+
+                    </div>
+</div>
+
+  </div>
+
+  </div>
+
+        </section>
+
+        <div class="right-rail">
+            <div class="right-rail-content">
+                  <div class="region region-right-sidebar">
+    <div id="block-manualfeaturedcards" class="block block-fixed-block-content block-fixed-block-contentmanual-featured-cards">
+
+
+
+
+<div class="news-card video">
+            <figure>
+            <a href="/pittwire/features-articles/gabel-council-competitiveness-education">
+                      	  	    <img src="/sites/default/files/styles/news_card_sidebar/public/2023-11/20220223_ao_machine_shop_0183_hero.jpg?h=b273ae4c&amp;itok=5WHtZ_O5" alt="People gather around a machine that makes quantum computing parts" loading="lazy" typeof="foaf:Image" class="image-style-news-card-sidebar" />
+
+
+
+
+            </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/gabel-council-competitiveness-education">      	  	  Chancellor Gabel highlights higher education’s role in keeping America competitive
+	        </a></h2>
+</div>
+
+
+
+<div class="news-card image">
+            <figure>
+            <a href="/pittwire/features-articles/shadow-bandits-eclipse-chasing">
+                      	  	    <img src="/sites/default/files/styles/news_card_sidebar/public/2023-10/20230909_ta_shadow-bandits_allegheny-observatory_0115_hero.jpg?h=77bf0f74&amp;itok=SMFN0NJ7" alt="One student fills a large weather balloon with air while another holds it above her head" loading="lazy" typeof="foaf:Image" class="image-style-news-card-sidebar" />
+
+
+
+
+            </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/shadow-bandits-eclipse-chasing">      	  	  These Pitt students are following the eclipse to Texas
+	        </a></h2>
+</div>
+
+
+
+
+  </div>
+
+    <div class="pittwire-heading">Trending</div>
+    <div><div class="view view-trending-articles view-id-trending_articles view-display-id-trending js-view-dom-id-184a372b9d5d3903504eb62973ae3928b9a462c42460c963885590c4675b0738">
+
+
+
+      <div class="view-content">
+          <div class="news-card views-row"><div class="views-field views-field-title"><span class="field-content"><h2 class="news-card-title"><a href="/pittwire/announcements-and-updates/new-winter-commencement-date-2024">Pitt’s winter commencement is now on Dec. 18</a></h2>
+</span></div></div>
+    <div class="news-card views-row"><div class="views-field views-field-title"><span class="field-content"><h2 class="news-card-title"><a href="/pittwire/announcements-and-updates/community-engaged-scholarship-project-development-cohort-2024">Apply for a program on developing community engaged scholarship projects</a></h2>
+</span></div></div>
+    <div class="news-card views-row"><div class="views-field views-field-title"><span class="field-content"><h2 class="news-card-title"><a href="/pittwire/accolades-honors/bradford-college-distinction-10-years">Pitt-Bradford has been a College of Distinction for a decade</a></h2>
+</span></div></div>
+
+    </div>
+
+          </div>
+</div>
+
+<!-- Subscribe Module -->
+<div id="block-subscribetopittwire" class="subscribe-wrapper block block-fixed-block-content block-fixed-block-contentsubscribe-to-pittwire">
+    <div class="subscribe-inner">
+          	        <figure class="field field--type-entity-reference field--label-hidden field__item">
+	  	    <img src="/sites/default/files/styles/subscription_callout/public/2021-07/img-pittwire-subscribe.png?h=7f3918f9&amp;itok=hC3ZYfSz" alt="FPO Tower" loading="lazy" typeof="foaf:Image" class="image-style-subscription-callout" />
+
+
+
+	  	  </figure>
+
+    <div class="subscribe-content">
+            	        <h2 class="subscribe-content-title field field--type-string field--label-hidden field__item">
+	  	  Subscribe to Pittwire Today
+	  	  </h2>
+
+            	  	  Get the most interesting and important stories from the University of Pittsburgh.
+
+    </div>
+  </div>
+  <div class="subscribe-form">
+    <div class="subscribe-form-btn">
+      <a href="/subscribe-pittwire" class="btn-submit">      	  	  Subscribe
+	        </a>
+    </div>
+  </div>
+  </div>
+
+  </div>
+
+            </div>
+        </div>
+    </div>
+
+</main>
+
+  <footer class="footer">
+                	        <div class="footer-bg field field--type-entity-reference field--label-hidden field__item">
+	  	    <img src="/sites/default/files/styles/footer_background/public/2021-03/img-bridge.png?itok=YCj_wGW3" alt="Bridge Icon" loading="lazy" typeof="foaf:Image" class="image-style-footer-background" />
+
+
+
+	  	  </div>
+
+  <div id="block-pitt-pittwire-footerblocks" class="footer-container">
+      <!-- Logo and Links -->
+<div class="footer-navigation" data-max-columns="2">
+      <div id="block-pitt-pittwire-sitebranding-2" class="footer-navigation-logo block block-system block-system-branding-block">
+
+
+        <a href="/" title="University of Pittsburgh" rel="home" class="site-logo">
+      <img src="/themes/custom/pitt_pittwire/logo.svg" alt="University of Pittsburgh" />
+    </a>
+    </div>
+<nav role="navigation" aria-labelledby="block-globalmenu-2-menu" id="block-globalmenu-2" class="menu--footer block block-menu navigation menu--global-menu">
+
+  <h2 class="visually-hidden" id="block-globalmenu-2-menu">Global Menu</h2>
+
+
+
+        <ul>
+          <li>
+        <a href="https://admissions.pitt.edu/apply/">Apply</a>
+      </li>
+          <li>
+        <a href="https://admissions.pitt.edu/visit/unscripted/">Visit</a>
+      </li>
+          <li>
+        <a href="https://www.giveto.pitt.edu/s/1729/18/home-giving.aspx?gid=2&amp;pgid=2135">Give</a>
+      </li>
+          <li>
+        <a href="/pittwire" data-drupal-link-system-path="node/18">Pittwire</a>
+      </li>
+          <li>
+        <a href="http://calendar.pitt.edu/">Events</a>
+      </li>
+        </ul>
+
+
+
+  </nav>
+
+  </div>
+<div class="footer-main" data-max-columns="2">
+      <!-- Footer Main Menu -->
+<div class="footer-sitemap" data-max-columns="2">
+
+                    <ul>
+              <li>
+		<a href="/about" class="data-gtm-footerLinksCategory">About</a>
+        </li>
+                        <li>
+		<a href="/academics" class="data-gtm-footerLinksCategory">Academics</a>
+        </li>
+                        <li>
+		<a href="/admissions" class="data-gtm-footerLinksCategory">Admissions</a>
+        </li>
+            </ul>
+                      <ul>
+              <li>
+		<a href="/research" class="data-gtm-footerLinksCategory">Research</a>
+        </li>
+                        <li>
+		<a href="/student-life" class="data-gtm-footerLinksCategory">Life at Pitt</a>
+        </li>
+                        <li>
+		<a href="http://pittsburghpanthers.com/" class="data-gtm-footerLinksCategory">Athletics</a>
+        </li>
+            </ul>
+
+
+<!-- End Main Menu -->
+
+  </div>
+<div id="block-footerquicklinksandcontact-2" class="block block-blockgroup block-block-groupfooter-quick-links-and-contact">
+
+
+      <!-- Quick Links and Contact Info -->
+<div class="footer-quicklinks">
+  <!-- Quick Links -->
+  <div class="collapse--secondary" data-max-columns="2">
+      <div id="block-pitt-pittwire-footerquicklinkscolumn1" class="block block-blockgroup block-block-groupfooter-quick-links-column-1">
+
+
+      <!-- collapse item -->
+<div class="footer-quicklinks-item">
+  <button id="quick-links-resources" class="collapse-trigger--md collapsed footer-quicklinks-item-header" role="tab" data-toggle="collapse" data-target="#collapse-item-quick-links-resources" aria-expanded="false" aria-controls="collapse-item-quick-links-resources" data-gtm="">Quick Links &amp; Resources</button>
+  <div id="collapse-item-quick-links-resources" class="collapse-target--md collapse" role="tabpanel" aria-labelledby="quick-links-resources">
+    <div class="collapse-content">
+      <div class="footer-quicklinks-item-header">Quick Links &amp; Resources</div>
+
+        <ul>
+            <li>
+		<a href="https://www.diversity.pitt.edu/accessibility-statement" class="data-gtm-footerLinksKPI">Accessibility Statement</a>
+        </li>
+            <li>
+		<a href="https://www.affordability.pitt.edu/" class="data-gtm-footerLinksKPI">Affordability</a>
+        </li>
+            <li>
+		<a href="https://www.join.pitt.edu/" class="data-gtm-footerLinksKPI">Careers</a>
+        </li>
+            <li>
+		<a href="/about/general-info" class="data-gtm-footerLinksKPI">Consumer Info/Achievement</a>
+        </li>
+            <li>
+		<a href="/contact" class="data-gtm-footerLinksKPI">Contact Us</a>
+        </li>
+            <li>
+		<a href="https://www.academics.pitt.edu/programs/a-z" class="data-gtm-footerLinksKPI">Departments A-Z</a>
+        </li>
+            <li>
+		<a href="https://www.diversity.pitt.edu/" class="data-gtm-footerLinksKPI">Diversity, Equity and Inclusion</a>
+        </li>
+            <li>
+		<a href="https://find.pitt.edu/" class="data-gtm-footerLinksKPI">Find People</a>
+        </li>
+            <li>
+		<a href="https://www.technology.pitt.edu/" class="data-gtm-footerLinksKPI">Information Technology</a>
+        </li>
+            <li>
+		<a href="https://www.lgbtq.pitt.edu/" class="data-gtm-footerLinksKPI">LGBTQ+</a>
+        </li>
+            <li>
+		<a href="https://www.diversity.pitt.edu/notice-nondiscrimination-and-anti-harassment-policy-statement" class="data-gtm-footerLinksKPI">Nondiscrimination and Anti-Harassment Policy</a>
+        </li>
+            <li>
+		<a href="https://www.pitt.edu/privacy-policy" class="data-gtm-footerLinksKPI">Privacy Policy</a>
+        </li>
+            <li>
+		<a href="https://www.pitt.edu/accountability" class="data-gtm-footerLinksKPI">Promoting Accountability and Trust</a>
+        </li>
+            <li>
+		<a href="http://my.pitt.edu" class="data-gtm-footerLinksKPI">My Pitt</a>
+        </li>
+        </ul>
+
+
+
+          </div>
+  </div>
+</div>
+<!-- collapse item -->
+<div class="footer-quicklinks-item">
+  <button id="regional-campuses" class="collapse-trigger--md collapsed footer-quicklinks-item-header" role="tab" data-toggle="collapse" data-target="#collapse-item-regional-campuses" aria-expanded="false" aria-controls="collapse-item-regional-campuses" data-gtm="">Regional Campuses</button>
+  <div id="collapse-item-regional-campuses" class="collapse-target--md collapse" role="tabpanel" aria-labelledby="regional-campuses">
+    <div class="collapse-content">
+      <div class="footer-quicklinks-item-header">Regional Campuses</div>
+
+        <ul>
+            <li>
+		<a href="https://upb.pitt.edu/" class="data-gtm-footerLinksKPI">Bradford</a>
+        </li>
+            <li>
+		<a href="http://www.greensburg.pitt.edu/" class="data-gtm-footerLinksKPI">Greensburg</a>
+        </li>
+            <li>
+		<a href="https://www.johnstown.pitt.edu/" class="data-gtm-footerLinksKPI">Johnstown</a>
+        </li>
+            <li>
+		<a href="https://www.titusville.pitt.edu/" class="data-gtm-footerLinksKPI">Titusville</a>
+        </li>
+        </ul>
+
+
+
+          </div>
+  </div>
+</div>
+
+  </div>
+<div id="block-pitt-pittwire-footerquicklinkscolumn2" class="block block-blockgroup block-block-groupfooter-quick-links-column-2">
+
+
+      <!-- collapse item -->
+<div class="footer-quicklinks-item">
+  <button id="colleges-schools" class="collapse-trigger--md collapsed footer-quicklinks-item-header" role="tab" data-toggle="collapse" data-target="#collapse-item-colleges-schools" aria-expanded="false" aria-controls="collapse-item-colleges-schools" data-gtm="">Colleges &amp; Schools</button>
+  <div id="collapse-item-colleges-schools" class="collapse-target--md collapse" role="tabpanel" aria-labelledby="colleges-schools">
+    <div class="collapse-content">
+      <div class="footer-quicklinks-item-header">Colleges &amp; Schools</div>
+
+        <ul>
+            <li>
+		<a href="https://www.as.pitt.edu" class="data-gtm-footerLinksKPI">Arts &amp; Sciences</a>
+        </li>
+            <li>
+		<a href="https://www.business.pitt.edu" class="data-gtm-footerLinksKPI">Business</a>
+        </li>
+            <li>
+		<a href="https://www.sci.pitt.edu" class="data-gtm-footerLinksKPI">Computing &amp; Information</a>
+        </li>
+            <li>
+		<a href="https://www.dental.pitt.edu" class="data-gtm-footerLinksKPI">Dental Medicine</a>
+        </li>
+            <li>
+		<a href="https://www.education.pitt.edu" class="data-gtm-footerLinksKPI">Education</a>
+        </li>
+            <li>
+		<a href="https://www.engineering.pitt.edu" class="data-gtm-footerLinksKPI">Engineering</a>
+        </li>
+            <li>
+		<a href="https://www.cgs.pitt.edu" class="data-gtm-footerLinksKPI">General Studies</a>
+        </li>
+            <li>
+		<a href="https://www.shrs.pitt.edu" class="data-gtm-footerLinksKPI">Health &amp; Rehabilitation</a>
+        </li>
+            <li>
+		<a href="https://www.honors.pitt.edu" class="data-gtm-footerLinksKPI">Honors College</a>
+        </li>
+            <li>
+		<a href="https://www.law.pitt.edu" class="data-gtm-footerLinksKPI">Law</a>
+        </li>
+            <li>
+		<a href="https://www.medschool.pitt.edu" class="data-gtm-footerLinksKPI">Medicine</a>
+        </li>
+            <li>
+		<a href="https://www.nursing.pitt.edu" class="data-gtm-footerLinksKPI">Nursing</a>
+        </li>
+            <li>
+		<a href="https://www.pharmacy.pitt.edu" class="data-gtm-footerLinksKPI">Pharmacy</a>
+        </li>
+            <li>
+		<a href="https://www.gspia.pitt.edu" class="data-gtm-footerLinksKPI">Public &amp; Intl Affairs</a>
+        </li>
+            <li>
+		<a href="https://publichealth.pitt.edu/" class="data-gtm-footerLinksKPI">Public Health</a>
+        </li>
+            <li>
+		<a href="https://www.socialwork.pitt.edu/" class="data-gtm-footerLinksKPI">Social Work</a>
+        </li>
+        </ul>
+
+
+
+          </div>
+  </div>
+</div>
+
+  </div>
+
+    </div>
+</div>
+<div id="block-footercontact-2" class="footer-contact block block-blockgroup block-block-groupfooter-contact">
+
+
+      <div id="block-footersiteinformation-2" class="block block-block-content block-block-content60643064-ee6c-4394-90c4-9e061373c0d4">
+
+
+            	        <div class="field field--type-address field--label-hidden field__item">
+	  	  <p class="address" translate="no"><span class="address-line1">4200 Fifth Ave.</span><br>
+<span class="locality">Pittsburgh</span>, <span class="administrative-area">PA</span> <span class="postal-code">15260</span><br>
+<span class="country">United States</span></p>
+	  	  </div>
+	              	        <div class="field field--type-telephone field--label-hidden field__item">
+	  	  <a href="tel:+1-412-624-4141">+1 412-624-4141</a>
+	  	  </div>
+
+  </div>
+<div id="block-socialmedialinks-2" class="block-social-media-links block block-social-media-links-block">
+
+
+
+
+<ul class="social-media-links--platforms platforms inline horizontal">
+      <li>
+      <a class="social-media-link-icon--twitter" href="https://www.twitter.com/PittTweet"  target="_blank" >
+          <i class="micon fa-twitter" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Twitter</span>
+      </a>
+    </li>
+      <li>
+      <a class="social-media-link-icon--instagram" href="https://www.instagram.com/pittofficial"  target="_blank" >
+          <i class="micon fa-instagram" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Instagram</span>
+      </a>
+    </li>
+      <li>
+      <a class="social-media-link-icon--facebook" href="https://www.facebook.com/upitt"  target="_blank" >
+          <i class="micon fa-facebook" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Facebook</span>
+      </a>
+    </li>
+      <li>
+      <a class="social-media-link-icon--youtube" href="https://www.youtube.com/user/pittweb"  target="_blank" >
+          <i class="micon fa-youtube" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Youtube</span>
+      </a>
+    </li>
+  </ul>
+
+  </div>
+
+  </div>
+
+  </div>
+
+  </div>
+
+  </div>
+
+  </footer>
+
+
+
+
+
+  </div>
+
+
+    <script type="application/json" data-drupal-selector="drupal-settings-json">{"path":{"baseUrl":"\/","scriptPath":null,"pathPrefix":"","currentPath":"pittwire\/news\/features-\u0026-articles","currentPathIsAdmin":false,"isFront":false,"currentLanguage":"en","currentQuery":{"field_article_date_value":"","field_category_target_id":"All","field_topics_target_id":"432","title":"fulbright"}},"pluralDelimiter":"\u0003","suppressDeprecationErrors":true,"ajaxPageState":{"libraries":"better_exposed_filters\/auto_submit,better_exposed_filters\/general,choices\/choices,core\/drupal.ajax,entity_overlay\/entity_overlay.behaviors,extlink\/drupal.extlink,media\/oembed.formatter,micon\/micon,paragraphs\/drupal.paragraphs.unpublished,pitt_default\/card,pitt_default\/choices,pitt_default\/global-styling,pitt_default\/media-item,pitt_default\/modal,social_media_links\/social_media_links.theme,system\/base,views\/views.module,zenny\/base,zensource_front_end\/classy.messages,zensource_front_end\/global-styling","theme":"pitt_pittwire","theme_token":"zjXQDBdTMt2mZC4y4bJWrE4DGi6Fcf67Lf6JMhH4rBU"},"ajaxTrustedUrl":{"\/pittwire\/news\/features-articles":true},"data":{"extlink":{"extTarget":false,"extTargetNoOverride":false,"extNofollow":false,"extNoreferrer":true,"extFollowNoOverride":false,"extClass":"0","extLabel":"(link is external)","extImgClass":false,"extSubdomains":true,"extExclude":"","extInclude":"","extCssExclude":"#block-socialmedialinks","extCssExplicit":"","extAlert":false,"extAlertText":"This link will take you to an external web site. We are not responsible for their content.","mailtoClass":"0","mailtoLabel":"(link sends email)","extUseFontAwesome":false,"extIconPlacement":"append","extFaLinkClasses":"fa fa-external-link","extFaMailtoClasses":"fa fa-envelope-o","whitelistedDomains":[]}},"entity_overlay":{"media_8412":{"overlay_url":"\/entity_overlay\/load\/nojs\/media\/8412\/modal","path_match":["media\/8412","\/media\/8412"],"dialog_type":"core_modal"}},"choices":{"cssSelector":["select[multiple=multiple]\r","select#edit-field-topics-target-id\r","select#edit-field-article-date-value\r","select#edit-field-pittwire-home-hero\r","select[id*=\u0022-subform-field-featured-article\u0022]"]},"user":{"uid":0,"permissionsHash":"45709791c536f1a56041d94d00891fba6b9156605a804ed14b7a260a9fb3cf47"}}</script>
+<script src="/themes/custom/pitt_default/js/gsap/dist/gsap.min.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/gsap/dist/ScrollTrigger.min.js?v=9.3.21"></script>
+<script src="/core/assets/vendor/jquery/jquery.min.js?v=3.6.0"></script>
+<script src="/core/misc/polyfills/element.matches.js?v=9.3.21"></script>
+<script src="/core/misc/polyfills/object.assign.js?v=9.3.21"></script>
+<script src="/core/assets/vendor/css-escape/css.escape.js?v=1.5.1"></script>
+<script src="/core/assets/vendor/once/once.min.js?v=1.0.1"></script>
+<script src="/core/assets/vendor/jquery-once/jquery.once.min.js?v=2.2.3"></script>
+<script src="/core/misc/drupalSettingsLoader.js?v=9.3.21"></script>
+<script src="/core/misc/drupal.js?v=9.3.21"></script>
+<script src="/core/misc/drupal.init.js?v=9.3.21"></script>
+<script src="/core/assets/vendor/tabbable/index.umd.min.js?v=5.2.1"></script>
+<script src="/core/misc/debounce.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/collapse-native.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/collapse.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/transition.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/hoverintent.min.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/navigation.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/userInterface.js?v=9.3.21"></script>
+<script src="/themes/contrib/zensource_front_end/js/global.js?v=9.3.21"></script>
+<script src="/core/misc/jquery.once.bc.js?v=9.3.21"></script>
+<script src="/modules/contrib/extlink/extlink.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/card.js?shklz9"></script>
+<script src="/modules/contrib/entity_overlay/js/behaviors.js?v=9.3.21"></script>
+<script src="/core/misc/progress.js?v=9.3.21"></script>
+<script src="/core/modules/responsive_image/js/responsive_image.ajax.js?v=9.3.21"></script>
+<script src="/core/misc/ajax.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/media-item.js?shklz9"></script>
+<script src="/modules/contrib/better_exposed_filters/js/better_exposed_filters.js?v=4.x"></script>
+<script src="/modules/contrib/better_exposed_filters/js/auto_submit.js?v=4.x"></script>
+<script src="/libraries/choices.js/public/assets/scripts/choices.min.js?shklz9"></script>
+<script src="/themes/contrib/zenny/js/choices.js?shklz9"></script>
+<script src="/themes/custom/pitt_default/js/filter-search.js?shklz9"></script>
+<script src="/themes/custom/pitt_default/js/modal-native.js?shklz9"></script>
+<script src="/themes/custom/pitt_default/js/modal.js?shklz9"></script>
+
+  <script type="text/javascript">window.NREUM||(NREUM={});NREUM.info={"beacon":"bam.nr-data.net","licenseKey":"NRJS-32db2f37a7e1f41235a","applicationID":"1009016335","transactionName":"NAAAYUNYCBFXVEddVw1KI1ZFUAkMGXNBQUgCCT5DWFwREWplXEFMCgsFaWdQAxVmVlRRewwLFkdeVQoHRBoNXFkNAQ5Q","queueTime":0,"applicationTime":205,"atts":"GEcDFwtCGx8=","errorBeacon":"bam.nr-data.net","agent":""}</script></body>
+</html>

--- a/tests/samples/news_university_news_features_articles_page_0.html
+++ b/tests/samples/news_university_news_features_articles_page_0.html
@@ -1,0 +1,1755 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr" prefix="content: http://purl.org/rss/1.0/modules/content/  dc: http://purl.org/dc/terms/  foaf: http://xmlns.com/foaf/0.1/  og: http://ogp.me/ns#  rdfs: http://www.w3.org/2000/01/rdf-schema#  schema: http://schema.org/  sioc: http://rdfs.org/sioc/ns#  sioct: http://rdfs.org/sioc/types#  skos: http://www.w3.org/2004/02/skos/core#  xsd: http://www.w3.org/2001/XMLSchema# ">
+  <head>
+    <meta charset="utf-8" /><script type="text/javascript">(window.NREUM||(NREUM={})).init={privacy:{cookies_enabled:true},ajax:{deny_list:["bam.nr-data.net"]}};(window.NREUM||(NREUM={})).loader_config={licenseKey:"NRJS-32db2f37a7e1f41235a",applicationID:"1009016335"};;/*! For license information please see nr-loader-rum-1.264.0.min.js.LICENSE.txt */
+(()=>{var e,t,r={2983:(e,t,r)=>{"use strict";r.d(t,{D0:()=>m,gD:()=>y,Vp:()=>s,fr:()=>S,jD:()=>I,hR:()=>E,xN:()=>b,x1:()=>c,aN:()=>R,V:()=>j});var n=r(384),i=r(7864);const o={beacon:n.NT.beacon,errorBeacon:n.NT.errorBeacon,licenseKey:void 0,applicationID:void 0,sa:void 0,queueTime:void 0,applicationTime:void 0,ttGuid:void 0,user:void 0,account:void 0,product:void 0,extra:void 0,jsAttributes:{},userAttributes:void 0,atts:void 0,transactionName:void 0,tNamePlain:void 0},a={};function s(e){if(!e)throw new Error("All info objects require an agent identifier!");if(!a[e])throw new Error("Info for ".concat(e," was never set"));return a[e]}function c(e,t){if(!e)throw new Error("All info objects require an agent identifier!");a[e]=(0,i.a)(t,o);const r=(0,n.nY)(e);r&&(r.info=a[e])}var u=r(993);const l=e=>{if(!e||"string"!=typeof e)return!1;try{document.createDocumentFragment().querySelector(e)}catch{return!1}return!0};var d=r(2614),g=r(944);const f="[data-nr-mask]",h=()=>{const e={mask_selector:"*",block_selector:"[data-nr-block]",mask_input_options:{color:!1,date:!1,"datetime-local":!1,email:!1,month:!1,number:!1,range:!1,search:!1,tel:!1,text:!1,time:!1,url:!1,week:!1,textarea:!1,select:!1,password:!0}};return{ajax:{deny_list:void 0,block_internal:!0,enabled:!0,harvestTimeSeconds:10,autoStart:!0},distributed_tracing:{enabled:void 0,exclude_newrelic_header:void 0,cors_use_newrelic_header:void 0,cors_use_tracecontext_headers:void 0,allowed_origins:void 0},feature_flags:[],generic_events:{enabled:!0,harvestTimeSeconds:30,autoStart:!0},harvest:{tooManyRequestsDelay:60},jserrors:{enabled:!0,harvestTimeSeconds:10,autoStart:!0},logging:{enabled:!0,harvestTimeSeconds:10,autoStart:!0,level:u.p_.INFO},metrics:{enabled:!0,autoStart:!0},obfuscate:void 0,page_action:{enabled:!0},page_view_event:{enabled:!0,autoStart:!0},page_view_timing:{enabled:!0,harvestTimeSeconds:30,long_task:!1,autoStart:!0},privacy:{cookies_enabled:!0},proxy:{assets:void 0,beacon:void 0},session:{expiresMs:d.wk,inactiveMs:d.BB},session_replay:{autoStart:!0,enabled:!1,harvestTimeSeconds:60,preload:!1,sampling_rate:10,error_sampling_rate:100,collect_fonts:!1,inline_images:!1,inline_stylesheet:!0,fix_stylesheets:!0,mask_all_inputs:!0,get mask_text_selector(){return e.mask_selector},set mask_text_selector(t){l(t)?e.mask_selector="".concat(t,",").concat(f):""===t||null===t?e.mask_selector=f:(0,g.R)(5,t)},get block_class(){return"nr-block"},get ignore_class(){return"nr-ignore"},get mask_text_class(){return"nr-mask"},get block_selector(){return e.block_selector},set block_selector(t){l(t)?e.block_selector+=",".concat(t):""!==t&&(0,g.R)(6,t)},get mask_input_options(){return e.mask_input_options},set mask_input_options(t){t&&"object"==typeof t?e.mask_input_options={...t,password:!0}:(0,g.R)(7,t)}},session_trace:{enabled:!0,harvestTimeSeconds:10,autoStart:!0},soft_navigations:{enabled:!0,harvestTimeSeconds:10,autoStart:!0},spa:{enabled:!0,harvestTimeSeconds:10,autoStart:!0},ssl:void 0}},p={},v="All configuration objects require an agent identifier!";function m(e){if(!e)throw new Error(v);if(!p[e])throw new Error("Configuration for ".concat(e," was never set"));return p[e]}function b(e,t){if(!e)throw new Error(v);p[e]=(0,i.a)(t,h());const r=(0,n.nY)(e);r&&(r.init=p[e])}function y(e,t){if(!e)throw new Error(v);var r=m(e);if(r){for(var n=t.split("."),i=0;i<n.length-1;i++)if("object"!=typeof(r=r[n[i]]))return;r=r[n[n.length-1]]}return r}const w={accountID:void 0,trustKey:void 0,agentID:void 0,licenseKey:void 0,applicationID:void 0,xpid:void 0},A={};function R(e,t){if(!e)throw new Error("All loader-config objects require an agent identifier!");A[e]=(0,i.a)(t,w);const r=(0,n.nY)(e);r&&(r.loader_config=A[e])}const E=(0,n.dV)().o;var x=r(6154),_=r(9324);const N={buildEnv:_.F3,distMethod:_.Xs,version:_.xv,originTime:x.WN},T={customTransaction:void 0,disabled:!1,isolatedBacklog:!1,loaderType:void 0,maxBytes:3e4,onerror:void 0,origin:""+x.gm.location,ptid:void 0,releaseIds:{},appMetadata:{},session:void 0,denyList:void 0,harvestCount:0,timeKeeper:void 0},k={};function S(e){if(!e)throw new Error("All runtime objects require an agent identifier!");if(!k[e])throw new Error("Runtime for ".concat(e," was never set"));return k[e]}function j(e,t){if(!e)throw new Error("All runtime objects require an agent identifier!");k[e]={...(0,i.a)(t,T),...N};const r=(0,n.nY)(e);r&&(r.runtime=k[e])}function I(e){return function(e){try{const t=s(e);return!!t.licenseKey&&!!t.errorBeacon&&!!t.applicationID}catch(e){return!1}}(e)}},7864:(e,t,r)=>{"use strict";r.d(t,{a:()=>i});var n=r(944);function i(e,t){try{if(!e||"object"!=typeof e)return(0,n.R)(3);if(!t||"object"!=typeof t)return(0,n.R)(4);const r=Object.create(Object.getPrototypeOf(t),Object.getOwnPropertyDescriptors(t)),o=0===Object.keys(r).length?e:r;for(let a in o)if(void 0!==e[a])try{if(null===e[a]){r[a]=null;continue}Array.isArray(e[a])&&Array.isArray(t[a])?r[a]=Array.from(new Set([...e[a],...t[a]])):"object"==typeof e[a]&&"object"==typeof t[a]?r[a]=i(e[a],t[a]):r[a]=e[a]}catch(e){(0,n.R)(1,e)}return r}catch(e){(0,n.R)(2,e)}}},9324:(e,t,r)=>{"use strict";r.d(t,{F3:()=>i,Xs:()=>o,xv:()=>n});const n="1.264.0",i="PROD",o="CDN"},6154:(e,t,r)=>{"use strict";r.d(t,{OF:()=>c,RI:()=>i,Vr:()=>l,WN:()=>d,bv:()=>o,gm:()=>a,mw:()=>s,sb:()=>u});var n=r(1863);const i="undefined"!=typeof window&&!!window.document,o="undefined"!=typeof WorkerGlobalScope&&("undefined"!=typeof self&&self instanceof WorkerGlobalScope&&self.navigator instanceof WorkerNavigator||"undefined"!=typeof globalThis&&globalThis instanceof WorkerGlobalScope&&globalThis.navigator instanceof WorkerNavigator),a=i?window:"undefined"!=typeof WorkerGlobalScope&&("undefined"!=typeof self&&self instanceof WorkerGlobalScope&&self||"undefined"!=typeof globalThis&&globalThis instanceof WorkerGlobalScope&&globalThis),s=Boolean("hidden"===a?.document?.visibilityState),c=/iPad|iPhone|iPod/.test(a.navigator?.userAgent),u=c&&"undefined"==typeof SharedWorker,l=((()=>{const e=a.navigator?.userAgent?.match(/Firefox[/\s](\d+\.\d+)/);Array.isArray(e)&&e.length>=2&&e[1]})(),!!a.navigator?.sendBeacon),d=Date.now()-(0,n.t)()},4777:(e,t,r)=>{"use strict";r.d(t,{J:()=>o});var n=r(944);const i={agentIdentifier:"",ee:void 0};class o{constructor(e){try{if("object"!=typeof e)return(0,n.R)(8);this.sharedContext={},Object.assign(this.sharedContext,i),Object.entries(e).forEach((e=>{let[t,r]=e;Object.keys(i).includes(t)&&(this.sharedContext[t]=r)}))}catch(e){(0,n.R)(9,e)}}}},1687:(e,t,r)=>{"use strict";r.d(t,{Ak:()=>s,Ze:()=>l,x3:()=>c});var n=r(7836),i=r(3606),o=r(860);const a={};function s(e,t){const r={staged:!1,priority:o.P[t]||0};u(e),a[e].get(t)||a[e].set(t,r)}function c(e,t){e&&a[e]&&(a[e].get(t)&&a[e].delete(t),g(e,t,!1),a[e].size&&d(e))}function u(e){if(!e)throw new Error("agentIdentifier required");a[e]||(a[e]=new Map)}function l(){let e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:"",t=arguments.length>1&&void 0!==arguments[1]?arguments[1]:"feature",r=arguments.length>2&&void 0!==arguments[2]&&arguments[2];if(u(e),!e||!a[e].get(t)||r)return g(e,t);a[e].get(t).staged=!0,d(e)}function d(e){const t=Array.from(a[e]);t.every((e=>{let[t,r]=e;return r.staged}))&&(t.sort(((e,t)=>e[1].priority-t[1].priority)),t.forEach((t=>{let[r]=t;a[e].delete(r),g(e,r)})))}function g(e,t){let r=!(arguments.length>2&&void 0!==arguments[2])||arguments[2];const o=e?n.ee.get(e):n.ee,a=i.i.handlers;if(!o.aborted&&o.backlog&&a){if(r){const e=o.backlog[t],r=a[t];if(r){for(let t=0;e&&t<e.length;++t)f(e[t],r);Object.entries(r).forEach((e=>{let[t,r]=e;Object.values(r||{}).forEach((e=>{e[0].on(t,e[1])}))}))}}o.isolatedBacklog||delete a[t],o.backlog[t]=null,o.emit("drain-"+t,[])}}function f(e,t){var r=e[1];Object.values(t[r]||{}).forEach((t=>{var r=e[0];if(t[0]===r){var n=t[1],i=e[3],o=e[2];n.apply(i,o)}}))}},7836:(e,t,r)=>{"use strict";r.d(t,{P:()=>c,ee:()=>u});var n=r(384),i=r(8990),o=r(2983),a=r(2646),s=r(5607);const c="nr@context:".concat(s.W),u=function e(t,r){var n={},s={},l={},d=!1;try{d=16===r.length&&(0,o.fr)(r).isolatedBacklog}catch(e){}var g={on:h,addEventListener:h,removeEventListener:function(e,t){var r=n[e];if(!r)return;for(var i=0;i<r.length;i++)r[i]===t&&r.splice(i,1)},emit:function(e,r,n,i,o){!1!==o&&(o=!0);if(u.aborted&&!i)return;t&&o&&t.emit(e,r,n);for(var a=f(n),c=p(e),l=c.length,d=0;d<l;d++)c[d].apply(a,r);var h=m()[s[e]];h&&h.push([g,e,r,a]);return a},get:v,listeners:p,context:f,buffer:function(e,t){const r=m();if(t=t||"feature",g.aborted)return;Object.entries(e||{}).forEach((e=>{let[n,i]=e;s[i]=t,t in r||(r[t]=[])}))},abort:function(){g._aborted=!0,Object.keys(g.backlog).forEach((e=>{delete g.backlog[e]}))},isBuffering:function(e){return!!m()[s[e]]},debugId:r,backlog:d?{}:t&&"object"==typeof t.backlog?t.backlog:{},isolatedBacklog:d};return Object.defineProperty(g,"aborted",{get:()=>{let e=g._aborted||!1;return e||(t&&(e=t.aborted),e)}}),g;function f(e){return e&&e instanceof a.y?e:e?(0,i.I)(e,c,(()=>new a.y(c))):new a.y(c)}function h(e,t){n[e]=p(e).concat(t)}function p(e){return n[e]||[]}function v(t){return l[t]=l[t]||e(g,t)}function m(){return g.backlog}}(void 0,"globalEE"),l=(0,n.Zm)();l.ee||(l.ee=u)},2646:(e,t,r)=>{"use strict";r.d(t,{y:()=>n});class n{constructor(e){this.contextId=e}}},9908:(e,t,r)=>{"use strict";r.d(t,{d:()=>n,p:()=>i});var n=r(7836).ee.get("handle");function i(e,t,r,i,o){o?(o.buffer([e],i),o.emit(e,t,r)):(n.buffer([e],i),n.emit(e,t,r))}},3606:(e,t,r)=>{"use strict";r.d(t,{i:()=>o});var n=r(9908);o.on=a;var i=o.handlers={};function o(e,t,r,o){a(o||n.d,i,e,t,r)}function a(e,t,r,i,o){o||(o="feature"),e||(e=n.d);var a=t[o]=t[o]||{};(a[r]=a[r]||[]).push([e,i])}},3878:(e,t,r)=>{"use strict";r.d(t,{DD:()=>c,jT:()=>a,sp:()=>s});var n=r(6154);let i=!1,o=!1;try{const e={get passive(){return i=!0,!1},get signal(){return o=!0,!1}};n.gm.addEventListener("test",null,e),n.gm.removeEventListener("test",null,e)}catch(e){}function a(e,t){return i||o?{capture:!!e,passive:i,signal:t}:!!e}function s(e,t){let r=arguments.length>2&&void 0!==arguments[2]&&arguments[2],n=arguments.length>3?arguments[3]:void 0;window.addEventListener(e,t,a(r,n))}function c(e,t){let r=arguments.length>2&&void 0!==arguments[2]&&arguments[2],n=arguments.length>3?arguments[3]:void 0;document.addEventListener(e,t,a(r,n))}},5607:(e,t,r)=>{"use strict";r.d(t,{W:()=>n});const n=(0,r(9566).bz)()},9566:(e,t,r)=>{"use strict";r.d(t,{LA:()=>s,bz:()=>a});var n=r(6154);const i="xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx";function o(e,t){return e?15&e[t]:16*Math.random()|0}function a(){const e=n.gm?.crypto||n.gm?.msCrypto;let t,r=0;return e&&e.getRandomValues&&(t=e.getRandomValues(new Uint8Array(30))),i.split("").map((e=>"x"===e?o(t,r++).toString(16):"y"===e?(3&o()|8).toString(16):e)).join("")}function s(e){const t=n.gm?.crypto||n.gm?.msCrypto;let r,i=0;t&&t.getRandomValues&&(r=t.getRandomValues(new Uint8Array(e)));const a=[];for(var s=0;s<e;s++)a.push(o(r,i++).toString(16));return a.join("")}},2614:(e,t,r)=>{"use strict";r.d(t,{BB:()=>a,H3:()=>n,g:()=>u,iL:()=>c,tS:()=>s,uh:()=>i,wk:()=>o});const n="NRBA",i="SESSION",o=144e5,a=18e5,s={STARTED:"session-started",PAUSE:"session-pause",RESET:"session-reset",RESUME:"session-resume",UPDATE:"session-update"},c={SAME_TAB:"same-tab",CROSS_TAB:"cross-tab"},u={OFF:0,FULL:1,ERROR:2}},1863:(e,t,r)=>{"use strict";function n(){return Math.floor(performance.now())}r.d(t,{t:()=>n})},944:(e,t,r)=>{"use strict";function n(e,t){"function"==typeof console.debug&&console.debug("New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/docs/warning-codes.md#".concat(e),t)}r.d(t,{R:()=>n})},5284:(e,t,r)=>{"use strict";r.d(t,{t:()=>c,B:()=>s});var n=r(7836),i=r(6154);const o="newrelic";const a=new Set,s={};function c(e,t){const r=n.ee.get(t);s[t]??={},e&&"object"==typeof e&&(a.has(t)||(r.emit("rumresp",[e]),s[t]=e,a.add(t),function(){let e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:{};try{i.gm.dispatchEvent(new CustomEvent(o,{detail:e}))}catch(e){}}({loaded:!0})))}},8990:(e,t,r)=>{"use strict";r.d(t,{I:()=>i});var n=Object.prototype.hasOwnProperty;function i(e,t,r){if(n.call(e,t))return e[t];var i=r();if(Object.defineProperty&&Object.keys)try{return Object.defineProperty(e,t,{value:i,writable:!0,enumerable:!1}),i}catch(e){}return e[t]=i,i}},6389:(e,t,r)=>{"use strict";function n(e){var t=this;let r=arguments.length>1&&void 0!==arguments[1]?arguments[1]:500,n=arguments.length>2&&void 0!==arguments[2]?arguments[2]:{};const i=n?.leading||!1;let o;return function(){for(var n=arguments.length,a=new Array(n),s=0;s<n;s++)a[s]=arguments[s];i&&void 0===o&&(e.apply(t,a),o=setTimeout((()=>{o=clearTimeout(o)}),r)),i||(clearTimeout(o),o=setTimeout((()=>{e.apply(t,a)}),r))}}function i(e){var t=this;let r=!1;return function(){if(!r){r=!0;for(var n=arguments.length,i=new Array(n),o=0;o<n;o++)i[o]=arguments[o];e.apply(t,i)}}}r.d(t,{J:()=>i,s:()=>n})},5289:(e,t,r)=>{"use strict";r.d(t,{GG:()=>o,sB:()=>a});var n=r(3878);function i(){return"undefined"==typeof document||"complete"===document.readyState}function o(e,t){if(i())return e();(0,n.sp)("load",e,t)}function a(e){if(i())return e();(0,n.DD)("DOMContentLoaded",e)}},384:(e,t,r)=>{"use strict";r.d(t,{NT:()=>o,US:()=>l,Zm:()=>a,bQ:()=>c,dV:()=>s,nY:()=>u,pV:()=>d});var n=r(6154),i=r(1863);const o={beacon:"bam.nr-data.net",errorBeacon:"bam.nr-data.net"};function a(){return n.gm.NREUM||(n.gm.NREUM={}),void 0===n.gm.newrelic&&(n.gm.newrelic=n.gm.NREUM),n.gm.NREUM}function s(){let e=a();return e.o||(e.o={ST:n.gm.setTimeout,SI:n.gm.setImmediate,CT:n.gm.clearTimeout,XHR:n.gm.XMLHttpRequest,REQ:n.gm.Request,EV:n.gm.Event,PR:n.gm.Promise,MO:n.gm.MutationObserver,FETCH:n.gm.fetch}),e}function c(e,t){let r=a();r.initializedAgents??={},t.initializedAt={ms:(0,i.t)(),date:new Date},r.initializedAgents[e]=t}function u(e){let t=a();return t.initializedAgents?.[e]}function l(e,t){a()[e]=t}function d(){return function(){let e=a();const t=e.info||{};e.info={beacon:o.beacon,errorBeacon:o.errorBeacon,...t}}(),function(){let e=a();const t=e.init||{};e.init={...t}}(),s(),function(){let e=a();const t=e.loader_config||{};e.loader_config={...t}}(),a()}},2843:(e,t,r)=>{"use strict";r.d(t,{u:()=>i});var n=r(3878);function i(e){let t=arguments.length>1&&void 0!==arguments[1]&&arguments[1],r=arguments.length>2?arguments[2]:void 0,i=arguments.length>3?arguments[3]:void 0;(0,n.DD)("visibilitychange",(function(){if(t)return void("hidden"===document.visibilityState&&e());e(document.visibilityState)}),r,i)}},3434:(e,t,r)=>{"use strict";r.d(t,{YM:()=>c});var n=r(7836),i=r(5607);const o="nr@original:".concat(i.W);var a=Object.prototype.hasOwnProperty,s=!1;function c(e,t){return e||(e=n.ee),r.inPlace=function(e,t,n,i,o){n||(n="");const a="-"===n.charAt(0);for(let s=0;s<t.length;s++){const c=t[s],u=e[c];l(u)||(e[c]=r(u,a?c+n:n,i,c,o))}},r.flag=o,r;function r(t,r,n,s,c){return l(t)?t:(r||(r=""),nrWrapper[o]=t,function(e,t,r){if(Object.defineProperty&&Object.keys)try{return Object.keys(e).forEach((function(r){Object.defineProperty(t,r,{get:function(){return e[r]},set:function(t){return e[r]=t,t}})})),t}catch(e){u([e],r)}for(var n in e)a.call(e,n)&&(t[n]=e[n])}(t,nrWrapper,e),nrWrapper);function nrWrapper(){var o,a,l,d;try{a=this,o=[...arguments],l="function"==typeof n?n(o,a):n||{}}catch(t){u([t,"",[o,a,s],l],e)}i(r+"start",[o,a,s],l,c);try{return d=t.apply(a,o)}catch(e){throw i(r+"err",[o,a,e],l,c),e}finally{i(r+"end",[o,a,d],l,c)}}}function i(r,n,i,o){if(!s||t){var a=s;s=!0;try{e.emit(r,n,i,t,o)}catch(t){u([t,r,n,i],e)}s=a}}}function u(e,t){t||(t=n.ee);try{t.emit("internal-error",e)}catch(e){}}function l(e){return!(e&&"function"==typeof e&&e.apply&&!e[o])}},993:(e,t,r)=>{"use strict";r.d(t,{ET:()=>o,p_:()=>i});var n=r(860);const i={ERROR:"ERROR",WARN:"WARN",INFO:"INFO",DEBUG:"DEBUG",TRACE:"TRACE"},o="log";n.K.logging},3969:(e,t,r)=>{"use strict";r.d(t,{TZ:()=>n,XG:()=>s,rs:()=>i,xV:()=>a,z_:()=>o});const n=r(860).K.metrics,i="sm",o="cm",a="storeSupportabilityMetrics",s="storeEventMetrics"},6630:(e,t,r)=>{"use strict";r.d(t,{T:()=>n});const n=r(860).K.pageViewEvent},782:(e,t,r)=>{"use strict";r.d(t,{T:()=>n});const n=r(860).K.pageViewTiming},6344:(e,t,r)=>{"use strict";r.d(t,{G4:()=>i});var n=r(2614);r(860).K.sessionReplay;const i={RECORD:"recordReplay",PAUSE:"pauseReplay",REPLAY_RUNNING:"replayRunning",ERROR_DURING_REPLAY:"errorDuringReplay"};n.g.ERROR,n.g.FULL,n.g.OFF},4234:(e,t,r)=>{"use strict";r.d(t,{W:()=>i});var n=r(7836);class i{constructor(e,t,r){this.agentIdentifier=e,this.aggregator=t,this.ee=n.ee.get(e),this.featureName=r,this.blocked=!1}}},2266:(e,t,r)=>{"use strict";r.d(t,{j:()=>k});var n=r(860),i=r(2983),o=r(9908),a=r(7836),s=r(1687),c=r(5289),u=r(6154),l=r(944),d=r(3969),g=r(384),f=r(6344);const h=["setErrorHandler","finished","addToTrace","addRelease","addPageAction","setCurrentRouteName","setPageViewName","setCustomAttribute","interaction","noticeError","setUserId","setApplicationVersion","start",f.G4.RECORD,f.G4.PAUSE,"log","wrapLogger"],p=["setErrorHandler","finished","addToTrace","addRelease"];var v=r(1863),m=r(2614),b=r(993);var y=r(2646),w=r(3434);function A(e,t,r,n){if("object"!=typeof t||!t||"string"!=typeof r||!r||"function"!=typeof t[r])return(0,l.R)(29);const i=function(e){return(e||a.ee).get("logger")}(e),o=(0,w.YM)(i),s=new y.y(a.P);return s.level=n.level,s.customAttributes=n.customAttributes,o.inPlace(t,[r],"wrap-logger-",s),i}function R(){const e=(0,g.pV)();h.forEach((t=>{e[t]=function(){for(var r=arguments.length,n=new Array(r),i=0;i<r;i++)n[i]=arguments[i];return function(t){for(var r=arguments.length,n=new Array(r>1?r-1:0),i=1;i<r;i++)n[i-1]=arguments[i];let o=[];return Object.values(e.initializedAgents).forEach((e=>{e&&e.api?e.exposed&&e.api[t]&&o.push(e.api[t](...n)):(0,l.R)(38,t)})),o.length>1?o:o[0]}(t,...n)}}))}const E={};function x(e,t){let g=arguments.length>2&&void 0!==arguments[2]&&arguments[2];t||(0,s.Ak)(e,"api");const h={};var y=a.ee.get(e),w=y.get("tracer");E[e]=m.g.OFF,y.on(f.G4.REPLAY_RUNNING,(t=>{E[e]=t}));var R="api-",x=R+"ixn-";function _(t,r,n,o){const a=(0,i.Vp)(e);return null===r?delete a.jsAttributes[t]:(0,i.x1)(e,{...a,jsAttributes:{...a.jsAttributes,[t]:r}}),k(R,n,!0,o||null===r?"session":void 0)(t,r)}function N(){}h.log=function(e){let{customAttributes:t={},level:r=b.p_.INFO}=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{};(0,o.p)(d.xV,["API/log/called"],void 0,n.K.metrics,y),function(e,t){let r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:{},i=arguments.length>3&&void 0!==arguments[3]?arguments[3]:b.p_.INFO;(0,o.p)(d.xV,["API/logging/".concat(i.toLowerCase(),"/called")],void 0,n.K.metrics,e),(0,o.p)(b.ET,[(0,v.t)(),t,r,i],void 0,n.K.logging,e)}(y,e,t,r)},h.wrapLogger=function(e,t){let{customAttributes:r={},level:i=b.p_.INFO}=arguments.length>2&&void 0!==arguments[2]?arguments[2]:{};(0,o.p)(d.xV,["API/wrapLogger/called"],void 0,n.K.metrics,y),A(y,e,t,{customAttributes:r,level:i})},p.forEach((e=>{h[e]=k(R,e,!0,"api")})),h.addPageAction=k(R,"addPageAction",!0,n.K.genericEvents),h.setPageViewName=function(t,r){if("string"==typeof t)return"/"!==t.charAt(0)&&(t="/"+t),(0,i.fr)(e).customTransaction=(r||"http://custom.transaction")+t,k(R,"setPageViewName",!0)()},h.setCustomAttribute=function(e,t){let r=arguments.length>2&&void 0!==arguments[2]&&arguments[2];if("string"==typeof e){if(["string","number","boolean"].includes(typeof t)||null===t)return _(e,t,"setCustomAttribute",r);(0,l.R)(40,typeof t)}else(0,l.R)(39,typeof e)},h.setUserId=function(e){if("string"==typeof e||null===e)return _("enduser.id",e,"setUserId",!0);(0,l.R)(41,typeof e)},h.setApplicationVersion=function(e){if("string"==typeof e||null===e)return _("application.version",e,"setApplicationVersion",!1);(0,l.R)(42,typeof e)},h.start=()=>{try{(0,o.p)(d.xV,["API/start/called"],void 0,n.K.metrics,y),y.emit("manual-start-all")}catch(e){(0,l.R)(23,e)}},h[f.G4.RECORD]=function(){(0,o.p)(d.xV,["API/recordReplay/called"],void 0,n.K.metrics,y),(0,o.p)(f.G4.RECORD,[],void 0,n.K.sessionReplay,y)},h[f.G4.PAUSE]=function(){(0,o.p)(d.xV,["API/pauseReplay/called"],void 0,n.K.metrics,y),(0,o.p)(f.G4.PAUSE,[],void 0,n.K.sessionReplay,y)},h.interaction=function(e){return(new N).get("object"==typeof e?e:{})};const T=N.prototype={createTracer:function(e,t){var r={},i=this,a="function"==typeof t;return(0,o.p)(d.xV,["API/createTracer/called"],void 0,n.K.metrics,y),g||(0,o.p)(x+"tracer",[(0,v.t)(),e,r],i,n.K.spa,y),function(){if(w.emit((a?"":"no-")+"fn-start",[(0,v.t)(),i,a],r),a)try{return t.apply(this,arguments)}catch(e){const t="string"==typeof e?new Error(e):e;throw w.emit("fn-err",[arguments,this,t],r),t}finally{w.emit("fn-end",[(0,v.t)()],r)}}}};function k(e,t,r,i){return function(){return(0,o.p)(d.xV,["API/"+t+"/called"],void 0,n.K.metrics,y),i&&(0,o.p)(e+t,[(0,v.t)(),...arguments],r?null:this,i,y),r?void 0:this}}function S(){r.e(296).then(r.bind(r,8778)).then((t=>{let{setAPI:r}=t;r(e),(0,s.Ze)(e,"api")})).catch((e=>{(0,l.R)(27,e),y.abort()}))}return["actionText","setName","setAttribute","save","ignore","onEnd","getContext","end","get"].forEach((e=>{T[e]=k(x,e,void 0,g?n.K.softNav:n.K.spa)})),h.setCurrentRouteName=g?k(x,"routeName",void 0,n.K.softNav):k(R,"routeName",!0,n.K.spa),h.noticeError=function(t,r){"string"==typeof t&&(t=new Error(t)),(0,o.p)(d.xV,["API/noticeError/called"],void 0,n.K.metrics,y),(0,o.p)("err",[t,(0,v.t)(),!1,r,!!E[e]],void 0,n.K.jserrors,y)},u.RI?(0,c.GG)((()=>S()),!0):S(),h}var _=r(5284);const N=e=>{const t=e.startsWith("http");e+="/",r.p=t?e:"https://"+e};let T=!1;function k(e){let t=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{},r=arguments.length>2?arguments[2]:void 0,n=arguments.length>3?arguments[3]:void 0,{init:o,info:s,loader_config:c,runtime:l={},exposed:d=!0}=t;l.loaderType=r;const f=(0,g.pV)();s||(o=f.init,s=f.info,c=f.loader_config),(0,i.xN)(e.agentIdentifier,o||{}),(0,i.aN)(e.agentIdentifier,c||{}),s.jsAttributes??={},u.bv&&(s.jsAttributes.isWorker=!0),(0,i.x1)(e.agentIdentifier,s);const h=(0,i.D0)(e.agentIdentifier),p=[s.beacon,s.errorBeacon];T||(h.proxy.assets&&(N(h.proxy.assets),p.push(h.proxy.assets)),h.proxy.beacon&&p.push(h.proxy.beacon),R(),(0,g.US)("activatedFeatures",_.B),e.runSoftNavOverSpa&&=!0===h.soft_navigations.enabled&&h.feature_flags.includes("soft_nav")),l.denyList=[...h.ajax.deny_list||[],...h.ajax.block_internal?p:[]],l.ptid=e.agentIdentifier,(0,i.V)(e.agentIdentifier,l),e.ee=a.ee.get(e.agentIdentifier),void 0===e.api&&(e.api=x(e.agentIdentifier,n,e.runSoftNavOverSpa)),void 0===e.exposed&&(e.exposed=d),T=!0}},8374:(e,t,r)=>{r.nc=(()=>{try{return document?.currentScript?.nonce}catch(e){}return""})()},860:(e,t,r)=>{"use strict";r.d(t,{K:()=>n,P:()=>i});const n={ajax:"ajax",genericEvents:"generic_events",jserrors:"jserrors",logging:"logging",metrics:"metrics",pageAction:"page_action",pageViewEvent:"page_view_event",pageViewTiming:"page_view_timing",sessionReplay:"session_replay",sessionTrace:"session_trace",softNav:"soft_navigations",spa:"spa"},i={[n.pageViewEvent]:1,[n.pageViewTiming]:2,[n.metrics]:3,[n.jserrors]:4,[n.spa]:5,[n.ajax]:6,[n.sessionTrace]:7,[n.softNav]:8,[n.sessionReplay]:9,[n.logging]:10,[n.genericEvents]:11}}},n={};function i(e){var t=n[e];if(void 0!==t)return t.exports;var o=n[e]={exports:{}};return r[e](o,o.exports,i),o.exports}i.m=r,i.d=(e,t)=>{for(var r in t)i.o(t,r)&&!i.o(e,r)&&Object.defineProperty(e,r,{enumerable:!0,get:t[r]})},i.f={},i.e=e=>Promise.all(Object.keys(i.f).reduce(((t,r)=>(i.f[r](e,t),t)),[])),i.u=e=>"nr-rum-1.264.0.min.js",i.o=(e,t)=>Object.prototype.hasOwnProperty.call(e,t),e={},t="NRBA-1.264.0.PROD:",i.l=(r,n,o,a)=>{if(e[r])e[r].push(n);else{var s,c;if(void 0!==o)for(var u=document.getElementsByTagName("script"),l=0;l<u.length;l++){var d=u[l];if(d.getAttribute("src")==r||d.getAttribute("data-webpack")==t+o){s=d;break}}if(!s){c=!0;var g={296:"sha512-/JFTCbNPZPe6tX1oowGTDXgTXJPZczBrsUMXw4/4Iz7c/U06sSfloejUIdps4/XHjV4Xx4uaRdele2Dq0BHQlw=="};(s=document.createElement("script")).charset="utf-8",s.timeout=120,i.nc&&s.setAttribute("nonce",i.nc),s.setAttribute("data-webpack",t+o),s.src=r,0!==s.src.indexOf(window.location.origin+"/")&&(s.crossOrigin="anonymous"),g[a]&&(s.integrity=g[a])}e[r]=[n];var f=(t,n)=>{s.onerror=s.onload=null,clearTimeout(h);var i=e[r];if(delete e[r],s.parentNode&&s.parentNode.removeChild(s),i&&i.forEach((e=>e(n))),t)return t(n)},h=setTimeout(f.bind(null,void 0,{type:"timeout",target:s}),12e4);s.onerror=f.bind(null,s.onerror),s.onload=f.bind(null,s.onload),c&&document.head.appendChild(s)}},i.r=e=>{"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(e,"__esModule",{value:!0})},i.p="https://js-agent.newrelic.com/",(()=>{var e={840:0,374:0};i.f.j=(t,r)=>{var n=i.o(e,t)?e[t]:void 0;if(0!==n)if(n)r.push(n[2]);else{var o=new Promise(((r,i)=>n=e[t]=[r,i]));r.push(n[2]=o);var a=i.p+i.u(t),s=new Error;i.l(a,(r=>{if(i.o(e,t)&&(0!==(n=e[t])&&(e[t]=void 0),n)){var o=r&&("load"===r.type?"missing":r.type),a=r&&r.target&&r.target.src;s.message="Loading chunk "+t+" failed.\n("+o+": "+a+")",s.name="ChunkLoadError",s.type=o,s.request=a,n[1](s)}}),"chunk-"+t,t)}};var t=(t,r)=>{var n,o,[a,s,c]=r,u=0;if(a.some((t=>0!==e[t]))){for(n in s)i.o(s,n)&&(i.m[n]=s[n]);if(c)c(i)}for(t&&t(r);u<a.length;u++)o=a[u],i.o(e,o)&&e[o]&&e[o][0](),e[o]=0},r=self["webpackChunk:NRBA-1.264.0.PROD"]=self["webpackChunk:NRBA-1.264.0.PROD"]||[];r.forEach(t.bind(null,0)),r.push=t.bind(null,r.push.bind(r))})(),(()=>{"use strict";i(8374);var e=i(944),t=i(6344),r=i(9566);class n{agentIdentifier;constructor(){let e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:(0,r.LA)(16);this.agentIdentifier=e}#e(t){for(var r=arguments.length,n=new Array(r>1?r-1:0),i=1;i<r;i++)n[i-1]=arguments[i];if("function"==typeof this.api?.[t])return this.api[t](...n);(0,e.R)(35,t)}addPageAction(e,t){return this.#e("addPageAction",e,t)}setPageViewName(e,t){return this.#e("setPageViewName",e,t)}setCustomAttribute(e,t,r){return this.#e("setCustomAttribute",e,t,r)}noticeError(e,t){return this.#e("noticeError",e,t)}setUserId(e){return this.#e("setUserId",e)}setApplicationVersion(e){return this.#e("setApplicationVersion",e)}setErrorHandler(e){return this.#e("setErrorHandler",e)}finished(e){return this.#e("finished",e)}addRelease(e,t){return this.#e("addRelease",e,t)}start(e){return this.#e("start",e)}recordReplay(){return this.#e(t.G4.RECORD)}pauseReplay(){return this.#e(t.G4.PAUSE)}addToTrace(e){return this.#e("addToTrace",e)}setCurrentRouteName(e){return this.#e("setCurrentRouteName",e)}interaction(){return this.#e("interaction")}log(e,t){return this.#e("logInfo",e,t)}wrapLogger(e,t,r){return this.#e("wrapLogger",e,t,r)}}var o=i(860),a=i(2983);const s=Object.values(o.K);function c(e){const t={};return s.forEach((r=>{t[r]=function(e,t){return!0===(0,a.gD)(t,"".concat(e,".enabled"))}(r,e)})),t}var u=i(2266);var l=i(1687),d=i(4234),g=i(5289),f=i(6154);const h=e=>f.RI&&!0===(0,a.gD)(e,"privacy.cookies_enabled");function p(e){return!!a.hR.MO&&h(e)&&!0===(0,a.gD)(e,"session_trace.enabled")}var v=i(6389);class m extends d.W{constructor(e,t,r){let n=!(arguments.length>3&&void 0!==arguments[3])||arguments[3];super(e,t,r),this.auto=n,this.abortHandler=void 0,this.featAggregate=void 0,this.onAggregateImported=void 0,!1===(0,a.gD)(this.agentIdentifier,"".concat(this.featureName,".autoStart"))&&(this.auto=!1),this.auto?(0,l.Ak)(e,r):this.ee.on("manual-start-all",(0,v.J)((()=>{(0,l.Ak)(this.agentIdentifier,this.featureName),this.auto=!0,this.importAggregator()})))}importAggregator(){let t,r=arguments.length>0&&void 0!==arguments[0]?arguments[0]:{};if(this.featAggregate||!this.auto)return;this.onAggregateImported=new Promise((e=>{t=e}));const n=async()=>{let n;try{if(h(this.agentIdentifier)){const{setupAgentSession:e}=await i.e(296).then(i.bind(i,2987));n=e(this.agentIdentifier)}}catch(t){(0,e.R)(20,t),this.ee.emit("internal-error",[t]),this.featureName===o.K.sessionReplay&&this.abortHandler?.()}try{if(!this.#t(this.featureName,n))return(0,l.Ze)(this.agentIdentifier,this.featureName),void t(!1);const{lazyFeatureLoader:e}=await i.e(296).then(i.bind(i,6103)),{Aggregate:o}=await e(this.featureName,"aggregate");this.featAggregate=new o(this.agentIdentifier,this.aggregator,r),t(!0)}catch(r){(0,e.R)(34,r),this.abortHandler?.(),(0,l.Ze)(this.agentIdentifier,this.featureName,!0),t(!1),this.ee&&this.ee.abort()}};f.RI?(0,g.GG)((()=>n()),!0):n()}#t(e,t){switch(e){case o.K.sessionReplay:return p(this.agentIdentifier)&&!!t;case o.K.sessionTrace:return!!t;default:return!0}}}var b=i(6630);class y extends m{static featureName=(()=>b.T)();constructor(e,t){let r=!(arguments.length>2&&void 0!==arguments[2])||arguments[2];super(e,t,b.T,r),this.importAggregator()}}var w=i(4777);class A extends w.J{constructor(e){super(e),this.aggregatedData={}}store(e,t,r,n,i){var o=this.getBucket(e,t,r,i);return o.metrics=function(e,t){t||(t={count:0});return t.count+=1,Object.entries(e||{}).forEach((e=>{let[r,n]=e;t[r]=R(n,t[r])})),t}(n,o.metrics),o}merge(e,t,r,n,i){var o=this.getBucket(e,t,n,i);if(o.metrics){var a=o.metrics;a.count+=r.count,Object.keys(r||{}).forEach((e=>{if("count"!==e){var t=a[e],n=r[e];n&&!n.c?a[e]=R(n.t,t):a[e]=function(e,t){if(!t)return e;t.c||(t=E(t.t));return t.min=Math.min(e.min,t.min),t.max=Math.max(e.max,t.max),t.t+=e.t,t.sos+=e.sos,t.c+=e.c,t}(n,a[e])}}))}else o.metrics=r}storeMetric(e,t,r,n){var i=this.getBucket(e,t,r);return i.stats=R(n,i.stats),i}getBucket(e,t,r,n){this.aggregatedData[e]||(this.aggregatedData[e]={});var i=this.aggregatedData[e][t];return i||(i=this.aggregatedData[e][t]={params:r||{}},n&&(i.custom=n)),i}get(e,t){return t?this.aggregatedData[e]&&this.aggregatedData[e][t]:this.aggregatedData[e]}take(e){for(var t={},r="",n=!1,i=0;i<e.length;i++)t[r=e[i]]=Object.values(this.aggregatedData[r]||{}),t[r].length&&(n=!0),delete this.aggregatedData[r];return n?t:null}}function R(e,t){return null==e?function(e){e?e.c++:e={c:1};return e}(t):t?(t.c||(t=E(t.t)),t.c+=1,t.t+=e,t.sos+=e*e,e>t.max&&(t.max=e),e<t.min&&(t.min=e),t):{t:e}}function E(e){return{t:e,min:e,max:e,sos:e*e,c:1}}var x=i(384);var _=i(9908),N=i(2843),T=i(3878),k=i(782),S=i(1863);class j extends m{static featureName=(()=>k.T)();constructor(e,t){let r=!(arguments.length>2&&void 0!==arguments[2])||arguments[2];super(e,t,k.T,r),f.RI&&((0,N.u)((()=>(0,_.p)("docHidden",[(0,S.t)()],void 0,k.T,this.ee)),!0),(0,T.sp)("pagehide",(()=>(0,_.p)("winPagehide",[(0,S.t)()],void 0,k.T,this.ee))),this.importAggregator())}}var I=i(3969);class O extends m{static featureName=(()=>I.TZ)();constructor(e,t){let r=!(arguments.length>2&&void 0!==arguments[2])||arguments[2];super(e,t,I.TZ,r),this.importAggregator()}}new class extends n{constructor(t,r){super(r),f.gm?(this.sharedAggregator=new A({agentIdentifier:this.agentIdentifier}),this.features={},(0,x.bQ)(this.agentIdentifier,this),this.desiredFeatures=new Set(t.features||[]),this.desiredFeatures.add(y),this.runSoftNavOverSpa=[...this.desiredFeatures].some((e=>e.featureName===o.K.softNav)),(0,u.j)(this,t,t.loaderType||"agent"),this.run()):(0,e.R)(21)}get config(){return{info:this.info,init:this.init,loader_config:this.loader_config,runtime:this.runtime}}run(){try{const t=c(this.agentIdentifier),r=[...this.desiredFeatures];r.sort(((e,t)=>o.P[e.featureName]-o.P[t.featureName])),r.forEach((r=>{if(!t[r.featureName]&&r.featureName!==o.K.pageViewEvent)return;if(this.runSoftNavOverSpa&&r.featureName===o.K.spa)return;if(!this.runSoftNavOverSpa&&r.featureName===o.K.softNav)return;(function(e){switch(e){case o.K.ajax:return[o.K.jserrors];case o.K.sessionTrace:return[o.K.ajax,o.K.pageViewEvent];case o.K.sessionReplay:return[o.K.sessionTrace];case o.K.pageViewTiming:return[o.K.pageViewEvent];default:return[]}})(r.featureName).every((e=>e in this.features))||(0,e.R)(36,r.featureName),this.features[r.featureName]=new r(this.agentIdentifier,this.sharedAggregator)}))}catch(t){(0,e.R)(22,t);for(const e in this.features)this.features[e].abortHandler?.();const r=(0,x.Zm)();delete r.initializedAgents[this.agentIdentifier]?.api,delete r.initializedAgents[this.agentIdentifier]?.features,delete this.sharedAggregator;return r.ee.get(this.agentIdentifier).abort(),!1}}}({features:[y,j,O],loaderType:"lite"})})()})();</script>
+<link rel="canonical" href="https://www.pitt.edu/pittwire/news/features-articles" />
+<meta property="og:site_name" content="University of Pittsburgh" />
+<meta property="og:type" content="website" />
+<meta property="og:url" content="https://www.pitt.edu/pittwire/news/features-articles" />
+<meta property="og:title" content="Pittwire News" />
+<meta name="MobileOptimized" content="width" />
+<meta name="HandheldFriendly" content="true" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<script type="application/ld+json">{
+    "@context": "https://schema.org",
+    "@graph": [
+        {
+            "@type": "Organization",
+            "@id": "https://www.pitt.edu/",
+            "name": "University of Pittsburgh",
+            "url": "https://www.pitt.edu/"
+        }
+    ]
+}</script>
+<link rel="icon" href="/sites/default/files/favicon.ico" type="image/vnd.microsoft.icon" />
+
+    <title>Pittwire News | University of Pittsburgh</title>
+    <link rel="stylesheet" media="all" href="/core/modules/system/css/components/ajax-progress.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/align.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/autocomplete-loading.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/fieldgroup.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/container-inline.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/clearfix.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/details.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/hidden.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/item-list.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/js.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/nowrap.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/position-container.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/progress.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/reset-appearance.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/resize.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/sticky-header.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/system-status-counter.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/system-status-report-counters.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/system-status-report-general-info.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/tabledrag.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/tablesort.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/tree-child.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/media/css/oembed.formatter.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/views/css/views.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/sites/default/files/micon/fa/style.css?shklz9" />
+<link rel="stylesheet" media="all" href="/modules/contrib/social_media_links/css/social_media_links.theme.css?shklz9" />
+<link rel="stylesheet" media="all" href="/modules/contrib/extlink/extlink.css?shklz9" />
+<link rel="stylesheet" media="all" href="/modules/contrib/paragraphs/css/paragraphs.unpublished.css?shklz9" />
+<link rel="stylesheet" media="all" href="/modules/contrib/better_exposed_filters/css/better_exposed_filters.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/global-styles.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/navigation.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/hero-banner.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/content-well.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/template-layout-mixin.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/collapse.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/footer-override.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/button.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/breadcrumb.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/cse.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/overrides.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/pittmag.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/contrib/zensource_front_end/css/components/hero-placeholder.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/contrib/zensource_front_end/css/classy/components/messages.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/contrib/zensource_front_end/css/classy/components/details.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/contrib/zenny/css/classy/components/pager.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/card.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/contrib/zensource_front_end/css/components/entity-overlay.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/media-item.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/pagination.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/choices.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/form.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/modal.css?shklz9" />
+
+
+	<!-- Google Tag Manager -->
+	<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+	new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+	j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+	'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+	})(window,document,'script','dataLayer','GTM-NXCGL72');</script>
+	<!-- End Google Tag Manager -->
+
+  <script async src="https://cse.google.com/cse.js?cx=013753980878518964357:mgrjnoukllc"></script>
+
+  </head>
+  <body class="path-pittwire">
+	<!-- Google Tag Manager (noscript) -->
+	<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NXCGL72"
+	height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+	<!-- End Google Tag Manager (noscript) -->
+
+        <a href="#main-content" class="visually-hidden focusable skip-link">
+      Skip to main content
+    </a>
+
+      <div class="dialog-off-canvas-main-canvas" data-off-canvas-main-canvas>
+
+
+        <div id="block-pitt-pittwire-sitebranding" class="block block-system block-system-branding-block">
+
+
+  <!-- global nav -->
+<div class="header-wrapper" role="region" aria-label="Navigation area">
+<header class="header pitt-wire">
+  <div class="header-container">
+    <div class="header-grid">
+      <div class="pitt-wire-nav">
+        <div class="logo">
+                      <div class="logo-pitt"><a href="/"><img src="/themes/custom/pitt_pittwire/logo.svg" alt="University of Pittsburgh"></a></div>
+            <div class="logo-pitt print-only"><img src="/themes/custom/pitt_pittwire/logo-print.png" alt="UPitt Logo"></div>
+                    <div class="logo-pitt-wire"><a href="/pittwire"><img src="/themes/custom/pitt_pittwire/logo-pittwire.svg" alt="Pitt Wire"></a></div>
+          <div class="logo-pitt-wire print-only"><img src="/themes/custom/pitt_pittwire/logo-pittwire-print.png" alt="Pitt Wire"></div>
+        </div>
+        <div class="explore-sections"><button class="" data-toggle="modal" data-target="#pitt-wire-menu" data-gtm="">Explore Sections</button></div>
+      </div>
+      <!-- main navigation -->
+      <div class="navigation" role="navigation" aria-label="Mega Menu">
+        <ul class="navigation-button-wrapper">
+          <li>
+            <button type="button" class="navigation-button" data-toggle="modal" data-target="#pittwire-search-menu" data-gtm="">
+              <span class="sr-only">open search</span>
+              <span class="icon-search"></span>
+            </button>
+          </li>
+          <li>
+            <button type="button" class="navigation-button" data-toggle="modal" data-target="#hamburger-menu" data-gtm="">
+              <span class="sr-only">open menu</span>
+              <span class="icon-hamburger"></span>
+            </button>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</header>
+</div>
+</div>
+
+
+<div id="pitt-wire-menu" class="modal modal--side navigation-slide-menu left pitt-wire-menu" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <!-- modal - header -->
+      <div class="modal-header">
+        <!-- modal - dismiss -->
+        <button type="button" class="modal-dismiss-button" data-dismiss="modal" aria-label="Close" data-gtm="">
+          <span class="sr-only">Close</span>
+        </button>
+      </div>
+      <!-- modal - body -->
+      <div class="modal-body">
+               	        <p class="field field--type-string-long field--label-hidden field__item">
+	  	  From the latest big breakthrough to the most influential and inspiring figures on campus to Pitt in the community, Pittwire is your official source for what’s happening now.
+	  	  </p>
+
+        <div class="hamburger-menu-wrapper">
+          <div class="hamburger-menu-upper">
+            <div id="block-pittwireexploretopics" class="hamburger-menu-upper-column block block-menu menu--pittwire-explore-topics">
+    <div class="hamburger-menu-header">Explore Sections</div>
+
+
+
+                <ul class="hamburger-menu-list">
+                    <li>
+                <a href="/pittwire/health-and-wellness" data-drupal-link-system-path="node/21">Health and Wellness</a>
+            </li>
+                    <li>
+                <a href="/pittwire/technology-and-science" data-drupal-link-system-path="node/13546">Technology and Science</a>
+            </li>
+                    <li>
+                <a href="/pittwire/arts-and-humanities" data-drupal-link-system-path="node/13547">Arts and Humanities</a>
+            </li>
+                    <li>
+                <a href="/pittwire/community-impact" data-drupal-link-system-path="node/13548">Community Impact</a>
+            </li>
+                    <li>
+                <a href="/pittwire/diversity-equity-and-inclusion" data-drupal-link-system-path="node/13551">Diversity, Equity, and Inclusion</a>
+            </li>
+                    <li>
+                <a href="/pittwire/global" data-drupal-link-system-path="node/13550">Global</a>
+            </li>
+                    <li>
+                <a href="/pittwire/innovation-and-research" data-drupal-link-system-path="node/13549">Innovation and Research</a>
+            </li>
+                    <li>
+                <a href="/pittwire/our-cityour-campus" data-drupal-link-system-path="node/13552">Our City/Our Campus</a>
+            </li>
+                    <li>
+                <a href="/pittwire/pittmagazine" data-drupal-link-system-path="pittwire/pittmagazine">Pitt Magazine</a>
+            </li>
+                </ul>
+
+
+
+    </div>
+            <div class="views-element-container hamburger-menu-upper-column block block-views block-views-blockcategory-menu-category-menu" id="block-views-block-category-menu-category-menu">
+            <div class="hamburger-menu-header">Explore By Category</div>
+                <div><div class="view view-category-menu view-id-category_menu view-display-id-category_menu js-view-dom-id-b170f5273de9e49d338bd391911f15a452a1aad3165e79a0130dcec5844e7ea5">
+
+
+
+      <div class="view-content">
+      <ul class="hamburger-menu-list">
+            <li><div class="views-field views-field-name"><span class="field-content"><a href="/pittwire/news/features-articles">Features &amp; Articles</a></span></div></li>
+            <li><div class="views-field views-field-name"><span class="field-content"><a href="/pittwire/news/accolades-honors">Accolades &amp; Honors</a></span></div></li>
+            <li><div class="views-field views-field-name"><span class="field-content"><a href="/pittwire/news/ones-to-watch">Ones to Watch</a></span></div></li>
+            <li><div class="views-field views-field-name"><span class="field-content"><a href="/pittwire/news/announcements-and-updates">Announcements and Updates</a></span></div></li>
+    </ul>
+
+    </div>
+
+          </div>
+</div>
+
+
+    <nav role="navigation" aria-labelledby="block-pittwireotherlinks-menu" id="block-pittwireotherlinks" class="block block-menu navigation menu--pittwire-other-links">
+
+  <h2 class="visually-hidden" id="block-pittwireotherlinks-menu">Pittwire Other Links</h2>
+
+
+
+<ul class="hamburger-menu-main">
+            <li>
+            <a href="https://calendar.pitt.edu/" target="_blank">Event Calendar</a>
+        </li>
+            <li>
+            <a href="https://www.pitt.edu/social" target="_blank">Social Media Directory</a>
+        </li>
+    </ul>
+
+
+
+  </nav>
+
+</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="search-menu" class="modal modal--side navigation-slide-menu right" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <!-- modal - header -->
+      <div class="modal-header">
+        <!-- modal - dismiss -->
+        <button type="button" class="modal-dismiss-button" data-dismiss="modal" aria-label="Close" data-gtm="">
+          <span class="sr-only">Close</span>
+        </button>
+      </div>
+      <!-- modal - body -->
+      <div class="modal-body">
+        <div class="search-menu-wrapper">
+          <div class="search-menu-header">Search Pitt</div>
+
+          <div class="search-menu-typeahead-wrapper">
+            <div class="search-menu-typeahead">
+              <label for="main-search-nav" class="sr-only">Search</label>
+
+              <!-- cse markup -->
+              <div class="gcse-searchbox-only" data-enableHistory="true" data-autoCompleteMaxCompletions="5" data-autoCompleteMatchType="any" data-resultsUrl="search-results"></div>
+
+            </div>
+
+          </div>
+
+
+          <div class="search-menu-footer">
+            <a href="https://find.pitt.edu" class="arrow">Search for People</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<div id="hamburger-menu" class="modal modal--side navigation-slide-menu right" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <!-- modal - header -->
+      <div class="modal-header">
+        <!-- modal - dismiss -->
+        <button type="button" class="modal-dismiss-button" data-dismiss="modal" aria-label="Close" data-gtm="">
+          <span class="sr-only">Close</span>
+        </button>
+      </div>
+      <!-- modal - body -->
+      <div class="modal-body">
+        <div class="hamburger-menu-wrapper">
+                      <div id="block-hamburgermenuupper-2" class="hamburger-menu-upper block block-blockgroup block-block-grouphamburger-menu-upper">
+
+
+      <div id="block-hamburgermenuuppercolumn1" class="hamburger-menu-upper-column block block-blockgroup block-block-grouphamburger-menu-upper-column-1">
+
+
+      <nav role="navigation" aria-labelledby="block-globalmenu-3-menu" id="block-globalmenu-3" class="block block-menu navigation menu--global-menu">
+
+  <h2 class="visually-hidden" id="block-globalmenu-3-menu">Global Menu</h2>
+
+
+
+        <ul class="hamburger-menu-main">
+          <li>
+	  <a href="https://admissions.pitt.edu/apply/" class="data-gtm-utilityNavKPI" data-contentTitle="Apply">Apply</a>
+      </li>
+          <li>
+	  <a href="https://admissions.pitt.edu/visit/unscripted/" class="data-gtm-utilityNavKPI" data-contentTitle="Visit">Visit</a>
+      </li>
+          <li>
+	  <a href="https://www.giveto.pitt.edu/s/1729/18/home-giving.aspx?gid=2&amp;pgid=2135" class="data-gtm-utilityNavKPI" data-contentTitle="Give">Give</a>
+      </li>
+          <li>
+	  <a href="/pittwire" class="data-gtm-utilityNavKPI" data-contentTitle="Pittwire">Pittwire</a>
+      </li>
+          <li>
+	  <a href="http://calendar.pitt.edu/" class="data-gtm-utilityNavKPI" data-contentTitle="Events">Events</a>
+      </li>
+        </ul>
+
+
+
+  </nav>
+      <button is="menu-blockmain-btn" class="collapse-trigger--md collapsed hamburger-menu-header-btn" role="tab" data-toggle="collapse" data-target="#menu-blockmain" aria-expanded="false" aria-controls="menu-blockmain" data-gtm="">Navigation</button>
+<div class="collapse-target--md collapse" id="menu-blockmain" role="tabpanel" aria-labelledby="menu-blockmain-btn">
+
+
+  <div  id="block-navigation-2-menu" class="hamburger-menu-header">Navigation</div>
+
+
+
+        <ul class="hamburger-menu-list">
+          <li>
+		<a href="/about" class="data-gtm-utilityNavCategory" data-contentTitle="About">About</a>
+      </li>
+          <li>
+		<a href="/academics" class="data-gtm-utilityNavCategory" data-contentTitle="Academics">Academics</a>
+      </li>
+          <li>
+		<a href="/admissions" class="data-gtm-utilityNavCategory" data-contentTitle="Admissions">Admissions</a>
+      </li>
+          <li>
+		<a href="/research" class="data-gtm-utilityNavCategory" data-contentTitle="Research">Research</a>
+      </li>
+          <li>
+		<a href="/student-life" class="data-gtm-utilityNavCategory" data-contentTitle="Life at Pitt">Life at Pitt</a>
+      </li>
+          <li>
+		<a href="http://pittsburghpanthers.com/" class="data-gtm-utilityNavCategory" data-contentTitle="Athletics">Athletics</a>
+      </li>
+        </ul>
+
+
+
+  </div>
+
+  </div>
+<div id="block-hamburgermenuuppercolumn2" class="hamburger-menu-upper-column block block-blockgroup block-block-grouphamburger-menu-upper-">
+
+
+            <button is="menu-blockquick-links-3-btn" class="collapse-trigger--md collapsed hamburger-menu-header-btn" role="tab" data-toggle="collapse" data-target="#menu-blockquick-links-3" aria-expanded="false" aria-controls="menu-blockquick-links-3" data-gtm="">Colleges &amp; Schools</button>
+<div class="collapse-target--md collapse" id="menu-blockquick-links-3" role="tabpanel" aria-labelledby="menu-blockquick-links-3-btn">
+
+
+  <div  id="block-collegesschools-2-menu" class="hamburger-menu-header">Colleges &amp; Schools</div>
+
+
+
+        <ul class="hamburger-menu-list">
+          <li>
+		<a href="https://www.as.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Arts &amp; Sciences">Arts &amp; Sciences</a>
+      </li>
+          <li>
+		<a href="https://www.business.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Business">Business</a>
+      </li>
+          <li>
+		<a href="https://www.sci.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Computing &amp; Information">Computing &amp; Information</a>
+      </li>
+          <li>
+		<a href="https://www.dental.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Dental Medicine">Dental Medicine</a>
+      </li>
+          <li>
+		<a href="https://www.education.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Education">Education</a>
+      </li>
+          <li>
+		<a href="https://www.engineering.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Engineering">Engineering</a>
+      </li>
+          <li>
+		<a href="https://www.cgs.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="General Studies">General Studies</a>
+      </li>
+          <li>
+		<a href="https://www.shrs.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Health &amp; Rehabilitation">Health &amp; Rehabilitation</a>
+      </li>
+          <li>
+		<a href="https://www.honors.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Honors College">Honors College</a>
+      </li>
+          <li>
+		<a href="https://www.law.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Law">Law</a>
+      </li>
+          <li>
+		<a href="https://www.medschool.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Medicine">Medicine</a>
+      </li>
+          <li>
+		<a href="https://www.nursing.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Nursing">Nursing</a>
+      </li>
+          <li>
+		<a href="https://www.pharmacy.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Pharmacy">Pharmacy</a>
+      </li>
+          <li>
+		<a href="https://www.gspia.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Public &amp; Intl Affairs">Public &amp; Intl Affairs</a>
+      </li>
+          <li>
+		<a href="https://publichealth.pitt.edu/" class="data-gtm-utilityNavCategory" data-contentTitle="Public Health">Public Health</a>
+      </li>
+          <li>
+		<a href="https://www.socialwork.pitt.edu/" class="data-gtm-utilityNavCategory" data-contentTitle="Social Work">Social Work</a>
+      </li>
+        </ul>
+
+
+
+  </div>
+
+  </div>
+
+  </div>
+<div id="block-hamburgermenulower" class="hamburger-menu-lower block block-blockgroup block-block-grouphamburger-menu-lower">
+
+
+      <div id="block-hamburgermenulowercolumn1" class="hamburger-menu-lower-column block block-blockgroup block-block-grouphamburger-menu-lower-column-1">
+
+
+            <button is="menu-blockinfo-menu-btn" class="collapse-trigger--md collapsed hamburger-menu-header-btn" role="tab" data-toggle="collapse" data-target="#menu-blockinfo-menu" aria-expanded="false" aria-controls="menu-blockinfo-menu" data-gtm="">Info For</button>
+<div class="collapse-target--md collapse" id="menu-blockinfo-menu" role="tabpanel" aria-labelledby="menu-blockinfo-menu-btn">
+
+
+  <div  id="block-infomenu-2-menu" class="hamburger-menu-header">Info For</div>
+
+
+
+            <ul class="hamburger-menu-list">
+      <li class="hamburger-menu-list-wrapper">
+        <ul class="hamburger-menu-list">
+                              <li>
+			<a href="http://coronavirus.pitt.edu/" class="data-gtm-utilityNavCategory" data-contentTitle="COVID-19 Response">COVID-19 Response</a>
+            </li>
+                                        <li>
+			<a href="https://www.alumni.pitt.edu/s/1729/alumni/home.aspx?gid=2&amp;pgid=2381" class="data-gtm-utilityNavCategory" data-contentTitle="Alumni">Alumni</a>
+            </li>
+                                                                                </ul>
+        <ul class="hamburger-menu-list">
+                                                                  <li>
+			<a href="https://www.community.pitt.edu/" class="data-gtm-utilityNavCategory" data-contentTitle="Community">Community</a>
+            </li>
+                                        <li>
+			<a href="/global" class="data-gtm-utilityNavCategory" data-contentTitle="Global">Global</a>
+            </li>
+                                        <li>
+			<a href="https://www.sustainable.pitt.edu/" class="data-gtm-utilityNavCategory" data-contentTitle="Sustainability">Sustainability</a>
+            </li>
+                          </ul>
+      </li>
+    </ul>
+
+
+
+
+  </div>
+
+  </div>
+<div id="block-hamburgermenulowercolumn2" class="hamburger-menu-lower-column block block-blockgroup block-block-grouphamburger-menu-lower-column-2">
+
+
+      <div id="block-socialmedialinks-4" class="hamburger-menu-social block-social-media-links block block-social-media-links-block">
+
+
+
+
+<ul class="social-media-links--platforms platforms inline horizontal">
+      <li>
+      <a class="social-media-link-icon--twitter" href="https://www.twitter.com/PittTweet"  >
+          <i class="micon fa-twitter" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Twitter</span>
+      </a>
+    </li>
+      <li>
+      <a class="social-media-link-icon--instagram" href="https://www.instagram.com/pittofficial"  >
+          <i class="micon fa-instagram" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Instagram</span>
+      </a>
+    </li>
+      <li>
+      <a class="social-media-link-icon--facebook" href="https://www.facebook.com/upitt"  >
+          <i class="micon fa-facebook" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Facebook</span>
+      </a>
+    </li>
+      <li>
+      <a class="social-media-link-icon--youtube" href="https://www.youtube.com/user/pittweb"  >
+          <i class="micon fa-youtube" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Youtube</span>
+      </a>
+    </li>
+  </ul>
+
+  </div>
+
+  </div>
+
+  </div>
+
+                  </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="pittwire-search-menu" class="modal modal--side navigation-slide-menu right" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <!-- modal - header -->
+      <div class="modal-header">
+        <!-- modal - dismiss -->
+        <button type="button" class="modal-dismiss-button" data-dismiss="modal" aria-label="Close" data-gtm="">
+          <span class="sr-only">Close</span>
+        </button>
+      </div>
+      <!-- modal - body -->
+      <div class="modal-body">
+        <div class="search-menu-wrapper">
+          <div class="search-menu-header">Search Pittwire</div>
+
+          <div class="search-menu-typeahead-wrapper">
+            <div class="search-menu-typeahead">
+              <label for="main-search-nav" class="sr-only">Search</label>
+
+              <!-- cse markup -->
+              <div class="gcse-searchbox-only" data-enableHistory="true" data-autoCompleteMaxCompletions="5" data-autoCompleteMatchType="any" data-resultsUrl="/pittwire/search-results"></div>
+
+            </div>
+
+          </div>
+
+
+          <div class="search-menu-footer">
+            <a href="https://www.pitt.edu/search-results" class="arrow">Search www.pitt.edu</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+<main id="content" class="main-container">
+    <a id="main-content" tabindex="-1"></a>
+    <div class="layout--right-rail pittwire">
+
+        <section class="main-content">
+              <div class="region region-content">
+    <div id="block-pitt-pittwire-mainpagecontent" class="block block-system block-system-main-block">
+
+
+      <div class="views-element-container">
+<div class="view view-article-view view-id-article_view view-display-id-pittwire_news js-view-dom-id-d3880bdc17814c4091d6816a2d323c3e99834c6bebe0902cc1fc096f5f1bc72e">
+            <div class="page-header">
+            <div class="page-header-container">
+                                    <h1 class="page-header-title">Features &amp; Articles
+</h1>
+                            </div>
+        </div>
+                <div class="filter-module">
+            <div class="filter-container">
+                <div class="filter-wrapper">
+                    <h2 class="filter-wrapper-title">Filter By</h2>
+                    <form class="views-exposed-form bef-exposed-form" data-bef-auto-submit-full-form="" data-bef-auto-submit="" data-bef-auto-submit-delay="1000" novalidate="novalidate" data-drupal-selector="views-exposed-form-article-view-pittwire-news" action="/pittwire/news/features-articles" method="get" id="views-exposed-form-article-view-pittwire-news" accept-charset="UTF-8">
+  <div class="filter-grid">
+
+  <fieldset class="js-form-item js-form-type-select form-type-select js-form-item-field-topics-target-id form-item-field-topics-target-id form-group">
+          <label for="edit-field-topics-target-id">Search by topic</label>
+                <select data-drupal-selector="edit-field-topics-target-id" id="edit-field-topics-target-id" name="field_topics_target_id" class="form-select form-control"><option value="All">Topics</option><option value="432" selected="selected">University News</option><option value="2">Health and Wellness</option><option value="391">Technology &amp; Science</option><option value="4">Arts and Humanities</option><option value="6">Community Impact</option><option value="1">Innovation and Research</option><option value="9">Global</option><option value="8">Diversity, Equity, and Inclusion</option><option value="12">Our City/Our Campus</option><option value="7">Teaching &amp; Learning</option><option value="440">Space</option><option value="441">Ukraine</option><option value="470">Sustainability</option></select>
+                  </fieldset>
+
+  <fieldset class="js-form-item js-form-type-select form-type-select js-form-item-field-article-date-value form-item-field-article-date-value form-group">
+          <label for="edit-field-article-date-value">Search by date</label>
+                <select data-drupal-selector="edit-field-article-date-value" id="edit-field-article-date-value" name="field_article_date_value" class="form-select form-control"><option value="" selected="selected">Year</option><option value="2012">2012</option><option value="2015">2015</option><option value="2016">2016</option><option value="2017">2017</option><option value="2018">2018</option><option value="2019">2019</option><option value="2020">2020</option><option value="2021">2021</option><option value="2022">2022</option><option value="2023">2023</option><option value="2024">2024</option></select>
+                  </fieldset>
+
+  <fieldset class="form-title-search js-form-item js-form-type-textfield form-type-textfield js-form-item-title form-item-title form-no-label form-group">
+          <label for="edit-title" class="sr-only">Search News</label>
+                <input placeholder="Search News" data-bef-auto-submit-exclude="" data-drupal-selector="edit-title" type="text" id="edit-title" name="title" value="" size="30" maxlength="128" class="form-text form-control" />
+
+                  </fieldset>
+<input data-drupal-selector="edit-field-category-target-id" type="hidden" name="field_category_target_id" value="All" class="form-control" />
+<div data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-group" id="edit-actions"><input data-bef-auto-submit-click="" data-drupal-selector="edit-submit-article-view" type="submit" id="edit-submit-article-view" value="Apply" class="button js-form-submit form-submit btn btn-primary form-control" />
+</div>
+
+    <button type="button" class="filter-search-btn"><span class="icon-search"></span> <span class="sr-only">Search News</span></button>
+</div>
+
+</form>
+
+                </div>
+            </div>
+        </div>
+
+            <div class="listing-wrapper">
+            <div class="listing-container">
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/pittmagazine/features-articles/vernard-alexander-community-engagement">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-08/pittmagfall24_vernard-alexander_1100x750.jpg?h=8936511a&amp;itok=yBKgPP42" alt="Man with hands in pockets, standing in front of window." loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/pittmagazine/features-articles/vernard-alexander-community-engagement">      	  	  Questions for the ‘Connecting King’
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  Vernard Alexander, the new director of Pitt’s Homewood Community Engagement Center, sees himself as the ultimate connector.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Community Impact
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/pittmagazine/features-articles/paa-president-bill-pierce">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-07/52420924239_cc5db0a32e_k.jpg?h=00848b3b&amp;itok=RFTO8g59" alt="Man speaks into handheld microphone." loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/pittmagazine/features-articles/paa-president-bill-pierce">      	  	  The Pitt Alumni Association has a new president
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  Bill Pierce believes in the power of Pitt pride.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/nazerbayev-university-med-school-accreditation-2024">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-07/nu-graduation-2024_hero.jpg?h=de836872&amp;itok=E75EKuET" alt="A Nazarbayev University School of Medicine graduating class" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/nazerbayev-university-med-school-accreditation-2024">      	  	  A Pitt partnership established this Kazakhstan medical school, which just earned its first MD accreditation
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  Nazarbayev University School of Medicine is home to the only graduate-level MD program in Central Asia.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Global
+				</li>
+		      		        <li class="field__item">
+				Teaching &amp; Learning
+				</li>
+		      		        <li class="field__item">
+				School of Medicine
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/transfer-student-experience-support-summit">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-06/20240517_ao_transfer_students_0087-hero.jpg?h=de836872&amp;itok=nBOxDGO9" alt="A panel of four people sit at a table with microphones" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/transfer-student-experience-support-summit">      	  	  How Pitt is paving the way for transfer students
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  A recent summit covered the challenges transfer students face when moving to four-year colleges — and highlighted Pitt programs that help smooth the transition.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Undergraduate students
+				</li>
+		      		        <li class="field__item">
+				Prospective students
+				</li>
+		      		        <li class="field__item">
+				School of Education
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/panthers-forward-savi-affordability">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-06/panthersforward3_small.jpg?h=d8076212&amp;itok=xLnFXtq1" alt="Kayla Kendricks posing with graduation cords and a Panthers Forward stole" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/panthers-forward-savi-affordability">      	  	  Panthers Forward can now help graduates find loan forgiveness and repayment options
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  Pitt’s innovative debt-relief program has partnered with Savi, which can help some borrowers save thousands.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Students
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/cfo-executive-senior-vice-chancellor-dwayne-pinkney">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-05/20220324_evpfa_jb_002176_small.jpg?h=d8076212&amp;itok=ARmtfPZi" alt="Pinkney" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/cfo-executive-senior-vice-chancellor-dwayne-pinkney">      	  	  Dwayne Pinkney is Pitt’s new executive senior vice chancellor for administration and finance and CFO
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  As executive senior vice chancellor for administration and finance, he will serve as a key advisor to Chancellor Gabel and University leadership.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/vice-provost-student-affairs-carla-panzella">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2022-12/20210820_ao_carla_panzella_0023_smallhero.jpg?h=d8076212&amp;itok=Jw-MDOLZ" alt="Portrait of Carla Panzella." loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/vice-provost-student-affairs-carla-panzella">      	  	  Carla Panzella is named Pitt&#039;s vice provost for student affairs
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  She brings more than two decades of student-centered work to the role, effective June 1.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Students
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/michele-manuel-swanson-school-dean">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-05/zamora-20180124-uf-eng-sec-pitch-0838-sm-hero.jpg?h=d8076212&amp;itok=4QbbHKSv" alt="Michele V. Manuel " loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/michele-manuel-swanson-school-dean">      	  	  Michele V. Manuel is the first woman U. S. Steel Dean of the Swanson School of Engineering
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  The award-winning materials engineer, innovator and leader joins Pitt from the University of Florida Sept. 1.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Technology &amp; Science
+				</li>
+		      		        <li class="field__item">
+				Provost
+				</li>
+		      		        <li class="field__item">
+				Swanson School of Engineering
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/bradford-military-friendly-school-2024-25">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-05/aiden-hulings_small.jpg?h=d8076212&amp;itok=DJULWT6F" alt="Aiden Hulings" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/bradford-military-friendly-school-2024-25">      	  	  Pitt-Bradford earned its 14th consecutive Military Friendly designation
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  The gold level school has been recognized for embracing military students and their families and dedicating resources to ensure their success.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Community Impact
+				</li>
+		      		        <li class="field__item">
+				Pitt-Bradford
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/disability-resources-incoming-students">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-05/20240506_ao_highschool_tour_0088-hero.jpg?h=de836872&amp;itok=nFVys5ZV" alt="Four people walking outside on Pitt&#039;s campus" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/disability-resources-incoming-students">      	  	  Pitt invited local high schoolers to experience the University’s disability resources firsthand
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  The University for a Day event, May 6, included a campus tour, an information session featuring an alum and an admissions presentation.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Diversity, Equity, and Inclusion
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/eboni-zamani-gallaher-appointed-education-dean">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-05/eboni-preferred-headshot_small.jpg?h=d8076212&amp;itok=J-ipKGKb" alt="Zamani-Gallaher " loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/eboni-zamani-gallaher-appointed-education-dean">      	  	  Eboni Zamani-Gallaher is the new dean of Pitt’s School of Education
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  Since she joined Pitt in 2022, the interim dean’s scholarship on equitable participation in higher ed has secured more than $10 million in funding.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Teaching &amp; Learning
+				</li>
+		      		        <li class="field__item">
+				School of Education
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/campus-master-plan-2024-update">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-05/20231116_ao_leadership_beamsigning_0142_hero.jpg?h=de836872&amp;itok=GG1_yTkZ" alt="A beam is lifted to the top of a structure that is under construction" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/campus-master-plan-2024-update">      	  	  Pitt is updating its Campus Master Plan
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  The Office of Planning, Design and Construction will lead the update, which will strengthen the University’s commitment to sustainability, community engagement and more.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Our City/Our Campus
+				</li>
+		      		        <li class="field__item">
+				Pittsburgh Campus
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/senior-awards-2024">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-04/senior-award-winners-small-hero-700x570.jpg?h=d8076212&amp;itok=QpqyXfRk" alt="Nguyen and Leslie" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/senior-awards-2024">      	  	  Hear from the graduates who earned this year’s top University honors
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  Benjamin Leslie is this year’s Emma W. Locke awardee; the ODK Senior of the Year award goes to Joshua Nguyen.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Community Impact
+				</li>
+		      		        <li class="field__item">
+				Undergraduate students
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/spring-commencement-2024-recap">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-04/20240428_ao_undergrad_commencement_dsc_0502_hero.jpg?h=de836872&amp;itok=0l0xwp5-" alt="Graduates link arms after the ceremony" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/spring-commencement-2024-recap">      	  	  Spring commencement 2024, in photos
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  See the most exciting moments from Sunday’s ceremony.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Students
+				</li>
+		      		        <li class="field__item">
+				Commencement
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/2023-24-united-way-campaign-results">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-04/20231018_ta_pitt-united-way_kit-packing_0058_hero.jpg?h=de836872&amp;itok=ThSiFkAk" alt="ROC packs cereal into a United Way bag, held by a volunteer" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/2023-24-united-way-campaign-results">      	  	  This year’s United Way Campaign set University records
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  David N. DeJong and other campaign leaders say it’s a testament to the power and impact of Pitt people.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Division of Philanthropic &amp; Alumni Engagement
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/2024-aaas-members">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-04/aaas-hero-for-pittwire.png?h=0a8b3dff&amp;itok=vh1_eIIc" alt="A composite of Pitt winners with the American Academy of Arts and Sciences logo" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/2024-aaas-members">      	  	  Pitt has five new American Academy of Arts and Sciences members
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  Among the University’s honorees are American Cancer Society researchers, an archaeologist and Chancellor Joan Gabel.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Innovation and Research
+				</li>
+		      		        <li class="field__item">
+				Faculty
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/2023-2024-stories-roundup">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-04/20240304_ao_early_spring_0180_hero.jpg?h=de836872&amp;itok=LI9zwriA" alt="Groups of students walk by Schenley Plaza, with the Cathedral of Learning in the background" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/2023-2024-stories-roundup">      	  	  Catch up on the past year at Pitt with this tl;dr
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  From new leadership to community engagement honors, the University redefined what is possible in 2023-24.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/2024-discourse-and-dialogue-lessons">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-04/20240318_ao_liann_tsoukas_0251_hero.jpg?h=de836872&amp;itok=GX3pD-Ll" alt="A raised hand in a classroom" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/2024-discourse-and-dialogue-lessons">      	  	  5 key takeaways from Pitt’s first Year of Discourse and Dialogue
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  An April capstone event highlighted embracing differences and learning about the First Amendment as strategies to make difficult conversations easier.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Diversity, Equity, and Inclusion
+				</li>
+		      		        <li class="field__item">
+				Our City/Our Campus
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/2024-graduate-commencement-speakers">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-04/20231217_ao_winter_commencement_0785_hero.jpg?h=b2a82cf3&amp;itok=FyAsrpll" alt="A line of people play horns with Pitt flags" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/2024-graduate-commencement-speakers">      	  	  Here are the speakers for Pitt’s graduate school commencement ceremonies
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  Hear from alumni and pioneers leading the fields of infectious diseases, social work, entrepreneurship and more.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Graduate and professional students
+				</li>
+		      		        <li class="field__item">
+				Commencement
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/2024-spring-commencement-speaker-john-surma">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-04/surma-8_small.jpg?h=d8076212&amp;itok=CmZRn0-e" alt="John Surma in a gray suit" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/2024-spring-commencement-speaker-john-surma">      	  	  John Surma is Pitt’s 2024 spring commencement speaker
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  The University will also honor the Board of Trustees member and former U. S. Steel CEO with an honorary degree.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Commencement
+				</li>
+		      	    </ul>
+
+</div>
+
+            </div>
+        </div>
+
+
+  <nav class="pagination" aria-label="Pagination">
+    <h4 id="pagination-heading" class="visually-hidden">Pagination</h4>
+                <a class="pagination-link previous disabled" tabindex="-1" href="#" data-gtm="" aria-label="Previous"></a>
+          <ul class="pagination-list">
+                                <li class="pagination-item">
+                                          <a href="?field_topics_target_id=432&amp;field_article_date_value=&amp;title=&amp;field_category_target_id=All&amp;page=0" title="Current page" class="pagination-link active">
+            <span class="visually-hidden">
+              Current page
+            </span>1</a>
+        </li>
+              <li class="pagination-item">
+                                          <a href="?field_topics_target_id=432&amp;field_article_date_value=&amp;title=&amp;field_category_target_id=All&amp;page=1" title="Go to page 2" class="pagination-link">
+            <span class="visually-hidden">
+              Page
+            </span>2</a>
+        </li>
+              <li class="pagination-item">
+                                          <a href="?field_topics_target_id=432&amp;field_article_date_value=&amp;title=&amp;field_category_target_id=All&amp;page=2" title="Go to page 3" class="pagination-link">
+            <span class="visually-hidden">
+              Page
+            </span>3</a>
+        </li>
+              <li class="pagination-item">
+                                          <a href="?field_topics_target_id=432&amp;field_article_date_value=&amp;title=&amp;field_category_target_id=All&amp;page=3" title="Go to page 4" class="pagination-link">
+            <span class="visually-hidden">
+              Page
+            </span>4</a>
+        </li>
+              <li class="pagination-item">
+                                          <a href="?field_topics_target_id=432&amp;field_article_date_value=&amp;title=&amp;field_category_target_id=All&amp;page=4" title="Go to page 5" class="pagination-link">
+            <span class="visually-hidden">
+              Page
+            </span>5</a>
+        </li>
+              <li class="pagination-item">
+                                          <a href="?field_topics_target_id=432&amp;field_article_date_value=&amp;title=&amp;field_category_target_id=All&amp;page=5" title="Go to page 6" class="pagination-link">
+            <span class="visually-hidden">
+              Page
+            </span>6</a>
+        </li>
+              <li class="pagination-item">
+                                          <a href="?field_topics_target_id=432&amp;field_article_date_value=&amp;title=&amp;field_category_target_id=All&amp;page=6" title="Go to page 7" class="pagination-link">
+            <span class="visually-hidden">
+              Page
+            </span>7</a>
+        </li>
+              <li class="pagination-item">
+                                          <a href="?field_topics_target_id=432&amp;field_article_date_value=&amp;title=&amp;field_category_target_id=All&amp;page=7" title="Go to page 8" class="pagination-link">
+            <span class="visually-hidden">
+              Page
+            </span>8</a>
+        </li>
+              <li class="pagination-item">
+                                          <a href="?field_topics_target_id=432&amp;field_article_date_value=&amp;title=&amp;field_category_target_id=All&amp;page=8" title="Go to page 9" class="pagination-link">
+            <span class="visually-hidden">
+              Page
+            </span>9</a>
+        </li>
+              <li class="pagination-item">
+                                          <a href="?field_topics_target_id=432&amp;field_article_date_value=&amp;title=&amp;field_category_target_id=All&amp;page=9" title="Go to page 10" class="pagination-link">
+            <span class="visually-hidden">
+              Page
+            </span>10</a>
+        </li>
+                            <li class="pagination-item">...</li>
+                </ul>
+                <a class="pagination-link next" href="?field_topics_target_id=432&amp;field_article_date_value=&amp;title=&amp;field_category_target_id=All&amp;page=1" data-gtm="" aria-label="Next"><span class="visually-hidden">Next page</span></a>
+        </nav>
+
+                    </div>
+</div>
+
+  </div>
+
+  </div>
+
+        </section>
+
+        <div class="right-rail">
+            <div class="right-rail-content">
+                  <div class="region region-right-sidebar">
+    <div id="block-manualfeaturedcards" class="block block-fixed-block-content block-fixed-block-contentmanual-featured-cards">
+
+
+
+
+<div class="news-card video">
+            <figure>
+            <a href="/pittwire/features-articles/gabel-council-competitiveness-education">
+                      	  	    <img src="/sites/default/files/styles/news_card_sidebar/public/2023-11/20220223_ao_machine_shop_0183_hero.jpg?h=b273ae4c&amp;itok=5WHtZ_O5" alt="People gather around a machine that makes quantum computing parts" loading="lazy" typeof="foaf:Image" class="image-style-news-card-sidebar" />
+
+
+
+
+            </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/gabel-council-competitiveness-education">      	  	  Chancellor Gabel highlights higher education’s role in keeping America competitive
+	        </a></h2>
+</div>
+
+
+
+<div class="news-card image">
+            <figure>
+            <a href="/pittwire/features-articles/shadow-bandits-eclipse-chasing">
+                      	  	    <img src="/sites/default/files/styles/news_card_sidebar/public/2023-10/20230909_ta_shadow-bandits_allegheny-observatory_0115_hero.jpg?h=77bf0f74&amp;itok=SMFN0NJ7" alt="One student fills a large weather balloon with air while another holds it above her head" loading="lazy" typeof="foaf:Image" class="image-style-news-card-sidebar" />
+
+
+
+
+            </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/shadow-bandits-eclipse-chasing">      	  	  These Pitt students are following the eclipse to Texas
+	        </a></h2>
+</div>
+
+
+
+
+  </div>
+
+    <div class="pittwire-heading">Trending</div>
+    <div><div class="view view-trending-articles view-id-trending_articles view-display-id-trending js-view-dom-id-184a372b9d5d3903504eb62973ae3928b9a462c42460c963885590c4675b0738">
+
+
+
+      <div class="view-content">
+          <div class="news-card views-row"><div class="views-field views-field-title"><span class="field-content"><h2 class="news-card-title"><a href="/pittwire/announcements-and-updates/new-winter-commencement-date-2024">Pitt’s winter commencement is now on Dec. 18</a></h2>
+</span></div></div>
+    <div class="news-card views-row"><div class="views-field views-field-title"><span class="field-content"><h2 class="news-card-title"><a href="/pittwire/announcements-and-updates/community-engaged-scholarship-project-development-cohort-2024">Apply for a program on developing community engaged scholarship projects</a></h2>
+</span></div></div>
+    <div class="news-card views-row"><div class="views-field views-field-title"><span class="field-content"><h2 class="news-card-title"><a href="/pittwire/accolades-honors/bradford-college-distinction-10-years">Pitt-Bradford has been a College of Distinction for a decade</a></h2>
+</span></div></div>
+
+    </div>
+
+          </div>
+</div>
+
+<!-- Subscribe Module -->
+<div id="block-subscribetopittwire" class="subscribe-wrapper block block-fixed-block-content block-fixed-block-contentsubscribe-to-pittwire">
+    <div class="subscribe-inner">
+          	        <figure class="field field--type-entity-reference field--label-hidden field__item">
+	  	    <img src="/sites/default/files/styles/subscription_callout/public/2021-07/img-pittwire-subscribe.png?h=7f3918f9&amp;itok=hC3ZYfSz" alt="FPO Tower" loading="lazy" typeof="foaf:Image" class="image-style-subscription-callout" />
+
+
+
+	  	  </figure>
+
+    <div class="subscribe-content">
+            	        <h2 class="subscribe-content-title field field--type-string field--label-hidden field__item">
+	  	  Subscribe to Pittwire Today
+	  	  </h2>
+
+            	  	  Get the most interesting and important stories from the University of Pittsburgh.
+
+    </div>
+  </div>
+  <div class="subscribe-form">
+    <div class="subscribe-form-btn">
+      <a href="/subscribe-pittwire" class="btn-submit">      	  	  Subscribe
+	        </a>
+    </div>
+  </div>
+  </div>
+
+  </div>
+
+            </div>
+        </div>
+    </div>
+
+</main>
+
+  <footer class="footer">
+                	        <div class="footer-bg field field--type-entity-reference field--label-hidden field__item">
+	  	    <img src="/sites/default/files/styles/footer_background/public/2021-03/img-bridge.png?itok=YCj_wGW3" alt="Bridge Icon" loading="lazy" typeof="foaf:Image" class="image-style-footer-background" />
+
+
+
+	  	  </div>
+
+  <div id="block-pitt-pittwire-footerblocks" class="footer-container">
+      <!-- Logo and Links -->
+<div class="footer-navigation" data-max-columns="2">
+      <div id="block-pitt-pittwire-sitebranding-2" class="footer-navigation-logo block block-system block-system-branding-block">
+
+
+        <a href="/" title="University of Pittsburgh" rel="home" class="site-logo">
+      <img src="/themes/custom/pitt_pittwire/logo.svg" alt="University of Pittsburgh" />
+    </a>
+    </div>
+<nav role="navigation" aria-labelledby="block-globalmenu-2-menu" id="block-globalmenu-2" class="menu--footer block block-menu navigation menu--global-menu">
+
+  <h2 class="visually-hidden" id="block-globalmenu-2-menu">Global Menu</h2>
+
+
+
+        <ul>
+          <li>
+        <a href="https://admissions.pitt.edu/apply/">Apply</a>
+      </li>
+          <li>
+        <a href="https://admissions.pitt.edu/visit/unscripted/">Visit</a>
+      </li>
+          <li>
+        <a href="https://www.giveto.pitt.edu/s/1729/18/home-giving.aspx?gid=2&amp;pgid=2135">Give</a>
+      </li>
+          <li>
+        <a href="/pittwire" data-drupal-link-system-path="node/18">Pittwire</a>
+      </li>
+          <li>
+        <a href="http://calendar.pitt.edu/">Events</a>
+      </li>
+        </ul>
+
+
+
+  </nav>
+
+  </div>
+<div class="footer-main" data-max-columns="2">
+      <!-- Footer Main Menu -->
+<div class="footer-sitemap" data-max-columns="2">
+
+                    <ul>
+              <li>
+		<a href="/about" class="data-gtm-footerLinksCategory">About</a>
+        </li>
+                        <li>
+		<a href="/academics" class="data-gtm-footerLinksCategory">Academics</a>
+        </li>
+                        <li>
+		<a href="/admissions" class="data-gtm-footerLinksCategory">Admissions</a>
+        </li>
+            </ul>
+                      <ul>
+              <li>
+		<a href="/research" class="data-gtm-footerLinksCategory">Research</a>
+        </li>
+                        <li>
+		<a href="/student-life" class="data-gtm-footerLinksCategory">Life at Pitt</a>
+        </li>
+                        <li>
+		<a href="http://pittsburghpanthers.com/" class="data-gtm-footerLinksCategory">Athletics</a>
+        </li>
+            </ul>
+
+
+<!-- End Main Menu -->
+
+  </div>
+<div id="block-footerquicklinksandcontact-2" class="block block-blockgroup block-block-groupfooter-quick-links-and-contact">
+
+
+      <!-- Quick Links and Contact Info -->
+<div class="footer-quicklinks">
+  <!-- Quick Links -->
+  <div class="collapse--secondary" data-max-columns="2">
+      <div id="block-pitt-pittwire-footerquicklinkscolumn1" class="block block-blockgroup block-block-groupfooter-quick-links-column-1">
+
+
+      <!-- collapse item -->
+<div class="footer-quicklinks-item">
+  <button id="quick-links-resources" class="collapse-trigger--md collapsed footer-quicklinks-item-header" role="tab" data-toggle="collapse" data-target="#collapse-item-quick-links-resources" aria-expanded="false" aria-controls="collapse-item-quick-links-resources" data-gtm="">Quick Links &amp; Resources</button>
+  <div id="collapse-item-quick-links-resources" class="collapse-target--md collapse" role="tabpanel" aria-labelledby="quick-links-resources">
+    <div class="collapse-content">
+      <div class="footer-quicklinks-item-header">Quick Links &amp; Resources</div>
+
+        <ul>
+            <li>
+		<a href="https://www.diversity.pitt.edu/accessibility-statement" class="data-gtm-footerLinksKPI">Accessibility Statement</a>
+        </li>
+            <li>
+		<a href="https://www.affordability.pitt.edu/" class="data-gtm-footerLinksKPI">Affordability</a>
+        </li>
+            <li>
+		<a href="https://www.join.pitt.edu/" class="data-gtm-footerLinksKPI">Careers</a>
+        </li>
+            <li>
+		<a href="/about/general-info" class="data-gtm-footerLinksKPI">Consumer Info/Achievement</a>
+        </li>
+            <li>
+		<a href="/contact" class="data-gtm-footerLinksKPI">Contact Us</a>
+        </li>
+            <li>
+		<a href="https://www.academics.pitt.edu/programs/a-z" class="data-gtm-footerLinksKPI">Departments A-Z</a>
+        </li>
+            <li>
+		<a href="https://www.diversity.pitt.edu/" class="data-gtm-footerLinksKPI">Diversity, Equity and Inclusion</a>
+        </li>
+            <li>
+		<a href="https://find.pitt.edu/" class="data-gtm-footerLinksKPI">Find People</a>
+        </li>
+            <li>
+		<a href="https://www.technology.pitt.edu/" class="data-gtm-footerLinksKPI">Information Technology</a>
+        </li>
+            <li>
+		<a href="https://www.lgbtq.pitt.edu/" class="data-gtm-footerLinksKPI">LGBTQ+</a>
+        </li>
+            <li>
+		<a href="https://www.diversity.pitt.edu/notice-nondiscrimination-and-anti-harassment-policy-statement" class="data-gtm-footerLinksKPI">Nondiscrimination and Anti-Harassment Policy</a>
+        </li>
+            <li>
+		<a href="https://www.pitt.edu/privacy-policy" class="data-gtm-footerLinksKPI">Privacy Policy</a>
+        </li>
+            <li>
+		<a href="https://www.pitt.edu/accountability" class="data-gtm-footerLinksKPI">Promoting Accountability and Trust</a>
+        </li>
+            <li>
+		<a href="http://my.pitt.edu" class="data-gtm-footerLinksKPI">My Pitt</a>
+        </li>
+        </ul>
+
+
+
+          </div>
+  </div>
+</div>
+<!-- collapse item -->
+<div class="footer-quicklinks-item">
+  <button id="regional-campuses" class="collapse-trigger--md collapsed footer-quicklinks-item-header" role="tab" data-toggle="collapse" data-target="#collapse-item-regional-campuses" aria-expanded="false" aria-controls="collapse-item-regional-campuses" data-gtm="">Regional Campuses</button>
+  <div id="collapse-item-regional-campuses" class="collapse-target--md collapse" role="tabpanel" aria-labelledby="regional-campuses">
+    <div class="collapse-content">
+      <div class="footer-quicklinks-item-header">Regional Campuses</div>
+
+        <ul>
+            <li>
+		<a href="https://upb.pitt.edu/" class="data-gtm-footerLinksKPI">Bradford</a>
+        </li>
+            <li>
+		<a href="http://www.greensburg.pitt.edu/" class="data-gtm-footerLinksKPI">Greensburg</a>
+        </li>
+            <li>
+		<a href="https://www.johnstown.pitt.edu/" class="data-gtm-footerLinksKPI">Johnstown</a>
+        </li>
+            <li>
+		<a href="https://www.titusville.pitt.edu/" class="data-gtm-footerLinksKPI">Titusville</a>
+        </li>
+        </ul>
+
+
+
+          </div>
+  </div>
+</div>
+
+  </div>
+<div id="block-pitt-pittwire-footerquicklinkscolumn2" class="block block-blockgroup block-block-groupfooter-quick-links-column-2">
+
+
+      <!-- collapse item -->
+<div class="footer-quicklinks-item">
+  <button id="colleges-schools" class="collapse-trigger--md collapsed footer-quicklinks-item-header" role="tab" data-toggle="collapse" data-target="#collapse-item-colleges-schools" aria-expanded="false" aria-controls="collapse-item-colleges-schools" data-gtm="">Colleges &amp; Schools</button>
+  <div id="collapse-item-colleges-schools" class="collapse-target--md collapse" role="tabpanel" aria-labelledby="colleges-schools">
+    <div class="collapse-content">
+      <div class="footer-quicklinks-item-header">Colleges &amp; Schools</div>
+
+        <ul>
+            <li>
+		<a href="https://www.as.pitt.edu" class="data-gtm-footerLinksKPI">Arts &amp; Sciences</a>
+        </li>
+            <li>
+		<a href="https://www.business.pitt.edu" class="data-gtm-footerLinksKPI">Business</a>
+        </li>
+            <li>
+		<a href="https://www.sci.pitt.edu" class="data-gtm-footerLinksKPI">Computing &amp; Information</a>
+        </li>
+            <li>
+		<a href="https://www.dental.pitt.edu" class="data-gtm-footerLinksKPI">Dental Medicine</a>
+        </li>
+            <li>
+		<a href="https://www.education.pitt.edu" class="data-gtm-footerLinksKPI">Education</a>
+        </li>
+            <li>
+		<a href="https://www.engineering.pitt.edu" class="data-gtm-footerLinksKPI">Engineering</a>
+        </li>
+            <li>
+		<a href="https://www.cgs.pitt.edu" class="data-gtm-footerLinksKPI">General Studies</a>
+        </li>
+            <li>
+		<a href="https://www.shrs.pitt.edu" class="data-gtm-footerLinksKPI">Health &amp; Rehabilitation</a>
+        </li>
+            <li>
+		<a href="https://www.honors.pitt.edu" class="data-gtm-footerLinksKPI">Honors College</a>
+        </li>
+            <li>
+		<a href="https://www.law.pitt.edu" class="data-gtm-footerLinksKPI">Law</a>
+        </li>
+            <li>
+		<a href="https://www.medschool.pitt.edu" class="data-gtm-footerLinksKPI">Medicine</a>
+        </li>
+            <li>
+		<a href="https://www.nursing.pitt.edu" class="data-gtm-footerLinksKPI">Nursing</a>
+        </li>
+            <li>
+		<a href="https://www.pharmacy.pitt.edu" class="data-gtm-footerLinksKPI">Pharmacy</a>
+        </li>
+            <li>
+		<a href="https://www.gspia.pitt.edu" class="data-gtm-footerLinksKPI">Public &amp; Intl Affairs</a>
+        </li>
+            <li>
+		<a href="https://publichealth.pitt.edu/" class="data-gtm-footerLinksKPI">Public Health</a>
+        </li>
+            <li>
+		<a href="https://www.socialwork.pitt.edu/" class="data-gtm-footerLinksKPI">Social Work</a>
+        </li>
+        </ul>
+
+
+
+          </div>
+  </div>
+</div>
+
+  </div>
+
+    </div>
+</div>
+<div id="block-footercontact-2" class="footer-contact block block-blockgroup block-block-groupfooter-contact">
+
+
+      <div id="block-footersiteinformation-2" class="block block-block-content block-block-content60643064-ee6c-4394-90c4-9e061373c0d4">
+
+
+            	        <div class="field field--type-address field--label-hidden field__item">
+	  	  <p class="address" translate="no"><span class="address-line1">4200 Fifth Ave.</span><br>
+<span class="locality">Pittsburgh</span>, <span class="administrative-area">PA</span> <span class="postal-code">15260</span><br>
+<span class="country">United States</span></p>
+	  	  </div>
+	              	        <div class="field field--type-telephone field--label-hidden field__item">
+	  	  <a href="tel:+1-412-624-4141">+1 412-624-4141</a>
+	  	  </div>
+
+  </div>
+<div id="block-socialmedialinks-2" class="block-social-media-links block block-social-media-links-block">
+
+
+
+
+<ul class="social-media-links--platforms platforms inline horizontal">
+      <li>
+      <a class="social-media-link-icon--twitter" href="https://www.twitter.com/PittTweet"  target="_blank" >
+          <i class="micon fa-twitter" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Twitter</span>
+      </a>
+    </li>
+      <li>
+      <a class="social-media-link-icon--instagram" href="https://www.instagram.com/pittofficial"  target="_blank" >
+          <i class="micon fa-instagram" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Instagram</span>
+      </a>
+    </li>
+      <li>
+      <a class="social-media-link-icon--facebook" href="https://www.facebook.com/upitt"  target="_blank" >
+          <i class="micon fa-facebook" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Facebook</span>
+      </a>
+    </li>
+      <li>
+      <a class="social-media-link-icon--youtube" href="https://www.youtube.com/user/pittweb"  target="_blank" >
+          <i class="micon fa-youtube" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Youtube</span>
+      </a>
+    </li>
+  </ul>
+
+  </div>
+
+  </div>
+
+  </div>
+
+  </div>
+
+  </div>
+
+  </footer>
+
+
+
+
+
+  </div>
+
+
+    <script type="application/json" data-drupal-selector="drupal-settings-json">{"path":{"baseUrl":"\/","scriptPath":null,"pathPrefix":"","currentPath":"pittwire\/news\/features-\u0026-articles","currentPathIsAdmin":false,"isFront":false,"currentLanguage":"en","currentQuery":{"field_article_date_value":"","field_category_target_id":"All","field_topics_target_id":"432","title":""}},"pluralDelimiter":"\u0003","suppressDeprecationErrors":true,"ajaxPageState":{"libraries":"better_exposed_filters\/auto_submit,better_exposed_filters\/general,choices\/choices,core\/drupal.ajax,entity_overlay\/entity_overlay.behaviors,extlink\/drupal.extlink,media\/oembed.formatter,micon\/micon,paragraphs\/drupal.paragraphs.unpublished,pitt_default\/card,pitt_default\/choices,pitt_default\/global-styling,pitt_default\/media-item,pitt_default\/modal,pitt_default\/pagination,social_media_links\/social_media_links.theme,system\/base,views\/views.module,zenny\/base,zensource_front_end\/classy.messages,zensource_front_end\/global-styling","theme":"pitt_pittwire","theme_token":"zjXQDBdTMt2mZC4y4bJWrE4DGi6Fcf67Lf6JMhH4rBU"},"ajaxTrustedUrl":{"\/pittwire\/news\/features-articles":true},"data":{"extlink":{"extTarget":false,"extTargetNoOverride":false,"extNofollow":false,"extNoreferrer":true,"extFollowNoOverride":false,"extClass":"0","extLabel":"(link is external)","extImgClass":false,"extSubdomains":true,"extExclude":"","extInclude":"","extCssExclude":"#block-socialmedialinks","extCssExplicit":"","extAlert":false,"extAlertText":"This link will take you to an external web site. We are not responsible for their content.","mailtoClass":"0","mailtoLabel":"(link sends email)","extUseFontAwesome":false,"extIconPlacement":"append","extFaLinkClasses":"fa fa-external-link","extFaMailtoClasses":"fa fa-envelope-o","whitelistedDomains":[]}},"entity_overlay":{"media_8412":{"overlay_url":"\/entity_overlay\/load\/nojs\/media\/8412\/modal","path_match":["media\/8412","\/media\/8412"],"dialog_type":"core_modal"}},"choices":{"cssSelector":["select[multiple=multiple]\r","select#edit-field-topics-target-id\r","select#edit-field-article-date-value\r","select#edit-field-pittwire-home-hero\r","select[id*=\u0022-subform-field-featured-article\u0022]"]},"user":{"uid":0,"permissionsHash":"45709791c536f1a56041d94d00891fba6b9156605a804ed14b7a260a9fb3cf47"}}</script>
+<script src="/themes/custom/pitt_default/js/gsap/dist/gsap.min.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/gsap/dist/ScrollTrigger.min.js?v=9.3.21"></script>
+<script src="/core/assets/vendor/jquery/jquery.min.js?v=3.6.0"></script>
+<script src="/core/misc/polyfills/element.matches.js?v=9.3.21"></script>
+<script src="/core/misc/polyfills/object.assign.js?v=9.3.21"></script>
+<script src="/core/assets/vendor/css-escape/css.escape.js?v=1.5.1"></script>
+<script src="/core/assets/vendor/once/once.min.js?v=1.0.1"></script>
+<script src="/core/assets/vendor/jquery-once/jquery.once.min.js?v=2.2.3"></script>
+<script src="/core/misc/drupalSettingsLoader.js?v=9.3.21"></script>
+<script src="/core/misc/drupal.js?v=9.3.21"></script>
+<script src="/core/misc/drupal.init.js?v=9.3.21"></script>
+<script src="/core/assets/vendor/tabbable/index.umd.min.js?v=5.2.1"></script>
+<script src="/core/misc/debounce.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/collapse-native.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/collapse.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/transition.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/hoverintent.min.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/navigation.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/userInterface.js?v=9.3.21"></script>
+<script src="/themes/contrib/zensource_front_end/js/global.js?v=9.3.21"></script>
+<script src="/core/misc/jquery.once.bc.js?v=9.3.21"></script>
+<script src="/modules/contrib/extlink/extlink.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/card.js?shklz9"></script>
+<script src="/modules/contrib/entity_overlay/js/behaviors.js?v=9.3.21"></script>
+<script src="/core/misc/progress.js?v=9.3.21"></script>
+<script src="/core/modules/responsive_image/js/responsive_image.ajax.js?v=9.3.21"></script>
+<script src="/core/misc/ajax.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/media-item.js?shklz9"></script>
+<script src="/modules/contrib/better_exposed_filters/js/better_exposed_filters.js?v=4.x"></script>
+<script src="/modules/contrib/better_exposed_filters/js/auto_submit.js?v=4.x"></script>
+<script src="/libraries/choices.js/public/assets/scripts/choices.min.js?shklz9"></script>
+<script src="/themes/contrib/zenny/js/choices.js?shklz9"></script>
+<script src="/themes/custom/pitt_default/js/filter-search.js?shklz9"></script>
+<script src="/themes/custom/pitt_default/js/modal-native.js?shklz9"></script>
+<script src="/themes/custom/pitt_default/js/modal.js?shklz9"></script>
+
+  <script type="text/javascript">window.NREUM||(NREUM={});NREUM.info={"beacon":"bam.nr-data.net","licenseKey":"NRJS-32db2f37a7e1f41235a","applicationID":"1009016335","transactionName":"NAAAYUNYCBFXVEddVw1KI1ZFUAkMGXNBQUgCCT5DWFwREWplXEFMCgsFaWdQAxVmVlRRewwLFkdeVQoHRBoNXFkNAQ5Q","queueTime":0,"applicationTime":169,"atts":"GEcDFwtCGx8=","errorBeacon":"bam.nr-data.net","agent":""}</script></body>
+</html>

--- a/tests/samples/news_university_news_features_articles_page_1.html
+++ b/tests/samples/news_university_news_features_articles_page_1.html
@@ -1,0 +1,1743 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr" prefix="content: http://purl.org/rss/1.0/modules/content/  dc: http://purl.org/dc/terms/  foaf: http://xmlns.com/foaf/0.1/  og: http://ogp.me/ns#  rdfs: http://www.w3.org/2000/01/rdf-schema#  schema: http://schema.org/  sioc: http://rdfs.org/sioc/ns#  sioct: http://rdfs.org/sioc/types#  skos: http://www.w3.org/2004/02/skos/core#  xsd: http://www.w3.org/2001/XMLSchema# ">
+  <head>
+    <meta charset="utf-8" /><script type="text/javascript">(window.NREUM||(NREUM={})).init={privacy:{cookies_enabled:true},ajax:{deny_list:["bam.nr-data.net"]}};(window.NREUM||(NREUM={})).loader_config={licenseKey:"NRJS-32db2f37a7e1f41235a",applicationID:"1009016335"};;/*! For license information please see nr-loader-rum-1.264.0.min.js.LICENSE.txt */
+(()=>{var e,t,r={2983:(e,t,r)=>{"use strict";r.d(t,{D0:()=>m,gD:()=>y,Vp:()=>s,fr:()=>S,jD:()=>I,hR:()=>E,xN:()=>b,x1:()=>c,aN:()=>R,V:()=>j});var n=r(384),i=r(7864);const o={beacon:n.NT.beacon,errorBeacon:n.NT.errorBeacon,licenseKey:void 0,applicationID:void 0,sa:void 0,queueTime:void 0,applicationTime:void 0,ttGuid:void 0,user:void 0,account:void 0,product:void 0,extra:void 0,jsAttributes:{},userAttributes:void 0,atts:void 0,transactionName:void 0,tNamePlain:void 0},a={};function s(e){if(!e)throw new Error("All info objects require an agent identifier!");if(!a[e])throw new Error("Info for ".concat(e," was never set"));return a[e]}function c(e,t){if(!e)throw new Error("All info objects require an agent identifier!");a[e]=(0,i.a)(t,o);const r=(0,n.nY)(e);r&&(r.info=a[e])}var u=r(993);const l=e=>{if(!e||"string"!=typeof e)return!1;try{document.createDocumentFragment().querySelector(e)}catch{return!1}return!0};var d=r(2614),g=r(944);const f="[data-nr-mask]",h=()=>{const e={mask_selector:"*",block_selector:"[data-nr-block]",mask_input_options:{color:!1,date:!1,"datetime-local":!1,email:!1,month:!1,number:!1,range:!1,search:!1,tel:!1,text:!1,time:!1,url:!1,week:!1,textarea:!1,select:!1,password:!0}};return{ajax:{deny_list:void 0,block_internal:!0,enabled:!0,harvestTimeSeconds:10,autoStart:!0},distributed_tracing:{enabled:void 0,exclude_newrelic_header:void 0,cors_use_newrelic_header:void 0,cors_use_tracecontext_headers:void 0,allowed_origins:void 0},feature_flags:[],generic_events:{enabled:!0,harvestTimeSeconds:30,autoStart:!0},harvest:{tooManyRequestsDelay:60},jserrors:{enabled:!0,harvestTimeSeconds:10,autoStart:!0},logging:{enabled:!0,harvestTimeSeconds:10,autoStart:!0,level:u.p_.INFO},metrics:{enabled:!0,autoStart:!0},obfuscate:void 0,page_action:{enabled:!0},page_view_event:{enabled:!0,autoStart:!0},page_view_timing:{enabled:!0,harvestTimeSeconds:30,long_task:!1,autoStart:!0},privacy:{cookies_enabled:!0},proxy:{assets:void 0,beacon:void 0},session:{expiresMs:d.wk,inactiveMs:d.BB},session_replay:{autoStart:!0,enabled:!1,harvestTimeSeconds:60,preload:!1,sampling_rate:10,error_sampling_rate:100,collect_fonts:!1,inline_images:!1,inline_stylesheet:!0,fix_stylesheets:!0,mask_all_inputs:!0,get mask_text_selector(){return e.mask_selector},set mask_text_selector(t){l(t)?e.mask_selector="".concat(t,",").concat(f):""===t||null===t?e.mask_selector=f:(0,g.R)(5,t)},get block_class(){return"nr-block"},get ignore_class(){return"nr-ignore"},get mask_text_class(){return"nr-mask"},get block_selector(){return e.block_selector},set block_selector(t){l(t)?e.block_selector+=",".concat(t):""!==t&&(0,g.R)(6,t)},get mask_input_options(){return e.mask_input_options},set mask_input_options(t){t&&"object"==typeof t?e.mask_input_options={...t,password:!0}:(0,g.R)(7,t)}},session_trace:{enabled:!0,harvestTimeSeconds:10,autoStart:!0},soft_navigations:{enabled:!0,harvestTimeSeconds:10,autoStart:!0},spa:{enabled:!0,harvestTimeSeconds:10,autoStart:!0},ssl:void 0}},p={},v="All configuration objects require an agent identifier!";function m(e){if(!e)throw new Error(v);if(!p[e])throw new Error("Configuration for ".concat(e," was never set"));return p[e]}function b(e,t){if(!e)throw new Error(v);p[e]=(0,i.a)(t,h());const r=(0,n.nY)(e);r&&(r.init=p[e])}function y(e,t){if(!e)throw new Error(v);var r=m(e);if(r){for(var n=t.split("."),i=0;i<n.length-1;i++)if("object"!=typeof(r=r[n[i]]))return;r=r[n[n.length-1]]}return r}const w={accountID:void 0,trustKey:void 0,agentID:void 0,licenseKey:void 0,applicationID:void 0,xpid:void 0},A={};function R(e,t){if(!e)throw new Error("All loader-config objects require an agent identifier!");A[e]=(0,i.a)(t,w);const r=(0,n.nY)(e);r&&(r.loader_config=A[e])}const E=(0,n.dV)().o;var x=r(6154),_=r(9324);const N={buildEnv:_.F3,distMethod:_.Xs,version:_.xv,originTime:x.WN},T={customTransaction:void 0,disabled:!1,isolatedBacklog:!1,loaderType:void 0,maxBytes:3e4,onerror:void 0,origin:""+x.gm.location,ptid:void 0,releaseIds:{},appMetadata:{},session:void 0,denyList:void 0,harvestCount:0,timeKeeper:void 0},k={};function S(e){if(!e)throw new Error("All runtime objects require an agent identifier!");if(!k[e])throw new Error("Runtime for ".concat(e," was never set"));return k[e]}function j(e,t){if(!e)throw new Error("All runtime objects require an agent identifier!");k[e]={...(0,i.a)(t,T),...N};const r=(0,n.nY)(e);r&&(r.runtime=k[e])}function I(e){return function(e){try{const t=s(e);return!!t.licenseKey&&!!t.errorBeacon&&!!t.applicationID}catch(e){return!1}}(e)}},7864:(e,t,r)=>{"use strict";r.d(t,{a:()=>i});var n=r(944);function i(e,t){try{if(!e||"object"!=typeof e)return(0,n.R)(3);if(!t||"object"!=typeof t)return(0,n.R)(4);const r=Object.create(Object.getPrototypeOf(t),Object.getOwnPropertyDescriptors(t)),o=0===Object.keys(r).length?e:r;for(let a in o)if(void 0!==e[a])try{if(null===e[a]){r[a]=null;continue}Array.isArray(e[a])&&Array.isArray(t[a])?r[a]=Array.from(new Set([...e[a],...t[a]])):"object"==typeof e[a]&&"object"==typeof t[a]?r[a]=i(e[a],t[a]):r[a]=e[a]}catch(e){(0,n.R)(1,e)}return r}catch(e){(0,n.R)(2,e)}}},9324:(e,t,r)=>{"use strict";r.d(t,{F3:()=>i,Xs:()=>o,xv:()=>n});const n="1.264.0",i="PROD",o="CDN"},6154:(e,t,r)=>{"use strict";r.d(t,{OF:()=>c,RI:()=>i,Vr:()=>l,WN:()=>d,bv:()=>o,gm:()=>a,mw:()=>s,sb:()=>u});var n=r(1863);const i="undefined"!=typeof window&&!!window.document,o="undefined"!=typeof WorkerGlobalScope&&("undefined"!=typeof self&&self instanceof WorkerGlobalScope&&self.navigator instanceof WorkerNavigator||"undefined"!=typeof globalThis&&globalThis instanceof WorkerGlobalScope&&globalThis.navigator instanceof WorkerNavigator),a=i?window:"undefined"!=typeof WorkerGlobalScope&&("undefined"!=typeof self&&self instanceof WorkerGlobalScope&&self||"undefined"!=typeof globalThis&&globalThis instanceof WorkerGlobalScope&&globalThis),s=Boolean("hidden"===a?.document?.visibilityState),c=/iPad|iPhone|iPod/.test(a.navigator?.userAgent),u=c&&"undefined"==typeof SharedWorker,l=((()=>{const e=a.navigator?.userAgent?.match(/Firefox[/\s](\d+\.\d+)/);Array.isArray(e)&&e.length>=2&&e[1]})(),!!a.navigator?.sendBeacon),d=Date.now()-(0,n.t)()},4777:(e,t,r)=>{"use strict";r.d(t,{J:()=>o});var n=r(944);const i={agentIdentifier:"",ee:void 0};class o{constructor(e){try{if("object"!=typeof e)return(0,n.R)(8);this.sharedContext={},Object.assign(this.sharedContext,i),Object.entries(e).forEach((e=>{let[t,r]=e;Object.keys(i).includes(t)&&(this.sharedContext[t]=r)}))}catch(e){(0,n.R)(9,e)}}}},1687:(e,t,r)=>{"use strict";r.d(t,{Ak:()=>s,Ze:()=>l,x3:()=>c});var n=r(7836),i=r(3606),o=r(860);const a={};function s(e,t){const r={staged:!1,priority:o.P[t]||0};u(e),a[e].get(t)||a[e].set(t,r)}function c(e,t){e&&a[e]&&(a[e].get(t)&&a[e].delete(t),g(e,t,!1),a[e].size&&d(e))}function u(e){if(!e)throw new Error("agentIdentifier required");a[e]||(a[e]=new Map)}function l(){let e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:"",t=arguments.length>1&&void 0!==arguments[1]?arguments[1]:"feature",r=arguments.length>2&&void 0!==arguments[2]&&arguments[2];if(u(e),!e||!a[e].get(t)||r)return g(e,t);a[e].get(t).staged=!0,d(e)}function d(e){const t=Array.from(a[e]);t.every((e=>{let[t,r]=e;return r.staged}))&&(t.sort(((e,t)=>e[1].priority-t[1].priority)),t.forEach((t=>{let[r]=t;a[e].delete(r),g(e,r)})))}function g(e,t){let r=!(arguments.length>2&&void 0!==arguments[2])||arguments[2];const o=e?n.ee.get(e):n.ee,a=i.i.handlers;if(!o.aborted&&o.backlog&&a){if(r){const e=o.backlog[t],r=a[t];if(r){for(let t=0;e&&t<e.length;++t)f(e[t],r);Object.entries(r).forEach((e=>{let[t,r]=e;Object.values(r||{}).forEach((e=>{e[0].on(t,e[1])}))}))}}o.isolatedBacklog||delete a[t],o.backlog[t]=null,o.emit("drain-"+t,[])}}function f(e,t){var r=e[1];Object.values(t[r]||{}).forEach((t=>{var r=e[0];if(t[0]===r){var n=t[1],i=e[3],o=e[2];n.apply(i,o)}}))}},7836:(e,t,r)=>{"use strict";r.d(t,{P:()=>c,ee:()=>u});var n=r(384),i=r(8990),o=r(2983),a=r(2646),s=r(5607);const c="nr@context:".concat(s.W),u=function e(t,r){var n={},s={},l={},d=!1;try{d=16===r.length&&(0,o.fr)(r).isolatedBacklog}catch(e){}var g={on:h,addEventListener:h,removeEventListener:function(e,t){var r=n[e];if(!r)return;for(var i=0;i<r.length;i++)r[i]===t&&r.splice(i,1)},emit:function(e,r,n,i,o){!1!==o&&(o=!0);if(u.aborted&&!i)return;t&&o&&t.emit(e,r,n);for(var a=f(n),c=p(e),l=c.length,d=0;d<l;d++)c[d].apply(a,r);var h=m()[s[e]];h&&h.push([g,e,r,a]);return a},get:v,listeners:p,context:f,buffer:function(e,t){const r=m();if(t=t||"feature",g.aborted)return;Object.entries(e||{}).forEach((e=>{let[n,i]=e;s[i]=t,t in r||(r[t]=[])}))},abort:function(){g._aborted=!0,Object.keys(g.backlog).forEach((e=>{delete g.backlog[e]}))},isBuffering:function(e){return!!m()[s[e]]},debugId:r,backlog:d?{}:t&&"object"==typeof t.backlog?t.backlog:{},isolatedBacklog:d};return Object.defineProperty(g,"aborted",{get:()=>{let e=g._aborted||!1;return e||(t&&(e=t.aborted),e)}}),g;function f(e){return e&&e instanceof a.y?e:e?(0,i.I)(e,c,(()=>new a.y(c))):new a.y(c)}function h(e,t){n[e]=p(e).concat(t)}function p(e){return n[e]||[]}function v(t){return l[t]=l[t]||e(g,t)}function m(){return g.backlog}}(void 0,"globalEE"),l=(0,n.Zm)();l.ee||(l.ee=u)},2646:(e,t,r)=>{"use strict";r.d(t,{y:()=>n});class n{constructor(e){this.contextId=e}}},9908:(e,t,r)=>{"use strict";r.d(t,{d:()=>n,p:()=>i});var n=r(7836).ee.get("handle");function i(e,t,r,i,o){o?(o.buffer([e],i),o.emit(e,t,r)):(n.buffer([e],i),n.emit(e,t,r))}},3606:(e,t,r)=>{"use strict";r.d(t,{i:()=>o});var n=r(9908);o.on=a;var i=o.handlers={};function o(e,t,r,o){a(o||n.d,i,e,t,r)}function a(e,t,r,i,o){o||(o="feature"),e||(e=n.d);var a=t[o]=t[o]||{};(a[r]=a[r]||[]).push([e,i])}},3878:(e,t,r)=>{"use strict";r.d(t,{DD:()=>c,jT:()=>a,sp:()=>s});var n=r(6154);let i=!1,o=!1;try{const e={get passive(){return i=!0,!1},get signal(){return o=!0,!1}};n.gm.addEventListener("test",null,e),n.gm.removeEventListener("test",null,e)}catch(e){}function a(e,t){return i||o?{capture:!!e,passive:i,signal:t}:!!e}function s(e,t){let r=arguments.length>2&&void 0!==arguments[2]&&arguments[2],n=arguments.length>3?arguments[3]:void 0;window.addEventListener(e,t,a(r,n))}function c(e,t){let r=arguments.length>2&&void 0!==arguments[2]&&arguments[2],n=arguments.length>3?arguments[3]:void 0;document.addEventListener(e,t,a(r,n))}},5607:(e,t,r)=>{"use strict";r.d(t,{W:()=>n});const n=(0,r(9566).bz)()},9566:(e,t,r)=>{"use strict";r.d(t,{LA:()=>s,bz:()=>a});var n=r(6154);const i="xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx";function o(e,t){return e?15&e[t]:16*Math.random()|0}function a(){const e=n.gm?.crypto||n.gm?.msCrypto;let t,r=0;return e&&e.getRandomValues&&(t=e.getRandomValues(new Uint8Array(30))),i.split("").map((e=>"x"===e?o(t,r++).toString(16):"y"===e?(3&o()|8).toString(16):e)).join("")}function s(e){const t=n.gm?.crypto||n.gm?.msCrypto;let r,i=0;t&&t.getRandomValues&&(r=t.getRandomValues(new Uint8Array(e)));const a=[];for(var s=0;s<e;s++)a.push(o(r,i++).toString(16));return a.join("")}},2614:(e,t,r)=>{"use strict";r.d(t,{BB:()=>a,H3:()=>n,g:()=>u,iL:()=>c,tS:()=>s,uh:()=>i,wk:()=>o});const n="NRBA",i="SESSION",o=144e5,a=18e5,s={STARTED:"session-started",PAUSE:"session-pause",RESET:"session-reset",RESUME:"session-resume",UPDATE:"session-update"},c={SAME_TAB:"same-tab",CROSS_TAB:"cross-tab"},u={OFF:0,FULL:1,ERROR:2}},1863:(e,t,r)=>{"use strict";function n(){return Math.floor(performance.now())}r.d(t,{t:()=>n})},944:(e,t,r)=>{"use strict";function n(e,t){"function"==typeof console.debug&&console.debug("New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/docs/warning-codes.md#".concat(e),t)}r.d(t,{R:()=>n})},5284:(e,t,r)=>{"use strict";r.d(t,{t:()=>c,B:()=>s});var n=r(7836),i=r(6154);const o="newrelic";const a=new Set,s={};function c(e,t){const r=n.ee.get(t);s[t]??={},e&&"object"==typeof e&&(a.has(t)||(r.emit("rumresp",[e]),s[t]=e,a.add(t),function(){let e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:{};try{i.gm.dispatchEvent(new CustomEvent(o,{detail:e}))}catch(e){}}({loaded:!0})))}},8990:(e,t,r)=>{"use strict";r.d(t,{I:()=>i});var n=Object.prototype.hasOwnProperty;function i(e,t,r){if(n.call(e,t))return e[t];var i=r();if(Object.defineProperty&&Object.keys)try{return Object.defineProperty(e,t,{value:i,writable:!0,enumerable:!1}),i}catch(e){}return e[t]=i,i}},6389:(e,t,r)=>{"use strict";function n(e){var t=this;let r=arguments.length>1&&void 0!==arguments[1]?arguments[1]:500,n=arguments.length>2&&void 0!==arguments[2]?arguments[2]:{};const i=n?.leading||!1;let o;return function(){for(var n=arguments.length,a=new Array(n),s=0;s<n;s++)a[s]=arguments[s];i&&void 0===o&&(e.apply(t,a),o=setTimeout((()=>{o=clearTimeout(o)}),r)),i||(clearTimeout(o),o=setTimeout((()=>{e.apply(t,a)}),r))}}function i(e){var t=this;let r=!1;return function(){if(!r){r=!0;for(var n=arguments.length,i=new Array(n),o=0;o<n;o++)i[o]=arguments[o];e.apply(t,i)}}}r.d(t,{J:()=>i,s:()=>n})},5289:(e,t,r)=>{"use strict";r.d(t,{GG:()=>o,sB:()=>a});var n=r(3878);function i(){return"undefined"==typeof document||"complete"===document.readyState}function o(e,t){if(i())return e();(0,n.sp)("load",e,t)}function a(e){if(i())return e();(0,n.DD)("DOMContentLoaded",e)}},384:(e,t,r)=>{"use strict";r.d(t,{NT:()=>o,US:()=>l,Zm:()=>a,bQ:()=>c,dV:()=>s,nY:()=>u,pV:()=>d});var n=r(6154),i=r(1863);const o={beacon:"bam.nr-data.net",errorBeacon:"bam.nr-data.net"};function a(){return n.gm.NREUM||(n.gm.NREUM={}),void 0===n.gm.newrelic&&(n.gm.newrelic=n.gm.NREUM),n.gm.NREUM}function s(){let e=a();return e.o||(e.o={ST:n.gm.setTimeout,SI:n.gm.setImmediate,CT:n.gm.clearTimeout,XHR:n.gm.XMLHttpRequest,REQ:n.gm.Request,EV:n.gm.Event,PR:n.gm.Promise,MO:n.gm.MutationObserver,FETCH:n.gm.fetch}),e}function c(e,t){let r=a();r.initializedAgents??={},t.initializedAt={ms:(0,i.t)(),date:new Date},r.initializedAgents[e]=t}function u(e){let t=a();return t.initializedAgents?.[e]}function l(e,t){a()[e]=t}function d(){return function(){let e=a();const t=e.info||{};e.info={beacon:o.beacon,errorBeacon:o.errorBeacon,...t}}(),function(){let e=a();const t=e.init||{};e.init={...t}}(),s(),function(){let e=a();const t=e.loader_config||{};e.loader_config={...t}}(),a()}},2843:(e,t,r)=>{"use strict";r.d(t,{u:()=>i});var n=r(3878);function i(e){let t=arguments.length>1&&void 0!==arguments[1]&&arguments[1],r=arguments.length>2?arguments[2]:void 0,i=arguments.length>3?arguments[3]:void 0;(0,n.DD)("visibilitychange",(function(){if(t)return void("hidden"===document.visibilityState&&e());e(document.visibilityState)}),r,i)}},3434:(e,t,r)=>{"use strict";r.d(t,{YM:()=>c});var n=r(7836),i=r(5607);const o="nr@original:".concat(i.W);var a=Object.prototype.hasOwnProperty,s=!1;function c(e,t){return e||(e=n.ee),r.inPlace=function(e,t,n,i,o){n||(n="");const a="-"===n.charAt(0);for(let s=0;s<t.length;s++){const c=t[s],u=e[c];l(u)||(e[c]=r(u,a?c+n:n,i,c,o))}},r.flag=o,r;function r(t,r,n,s,c){return l(t)?t:(r||(r=""),nrWrapper[o]=t,function(e,t,r){if(Object.defineProperty&&Object.keys)try{return Object.keys(e).forEach((function(r){Object.defineProperty(t,r,{get:function(){return e[r]},set:function(t){return e[r]=t,t}})})),t}catch(e){u([e],r)}for(var n in e)a.call(e,n)&&(t[n]=e[n])}(t,nrWrapper,e),nrWrapper);function nrWrapper(){var o,a,l,d;try{a=this,o=[...arguments],l="function"==typeof n?n(o,a):n||{}}catch(t){u([t,"",[o,a,s],l],e)}i(r+"start",[o,a,s],l,c);try{return d=t.apply(a,o)}catch(e){throw i(r+"err",[o,a,e],l,c),e}finally{i(r+"end",[o,a,d],l,c)}}}function i(r,n,i,o){if(!s||t){var a=s;s=!0;try{e.emit(r,n,i,t,o)}catch(t){u([t,r,n,i],e)}s=a}}}function u(e,t){t||(t=n.ee);try{t.emit("internal-error",e)}catch(e){}}function l(e){return!(e&&"function"==typeof e&&e.apply&&!e[o])}},993:(e,t,r)=>{"use strict";r.d(t,{ET:()=>o,p_:()=>i});var n=r(860);const i={ERROR:"ERROR",WARN:"WARN",INFO:"INFO",DEBUG:"DEBUG",TRACE:"TRACE"},o="log";n.K.logging},3969:(e,t,r)=>{"use strict";r.d(t,{TZ:()=>n,XG:()=>s,rs:()=>i,xV:()=>a,z_:()=>o});const n=r(860).K.metrics,i="sm",o="cm",a="storeSupportabilityMetrics",s="storeEventMetrics"},6630:(e,t,r)=>{"use strict";r.d(t,{T:()=>n});const n=r(860).K.pageViewEvent},782:(e,t,r)=>{"use strict";r.d(t,{T:()=>n});const n=r(860).K.pageViewTiming},6344:(e,t,r)=>{"use strict";r.d(t,{G4:()=>i});var n=r(2614);r(860).K.sessionReplay;const i={RECORD:"recordReplay",PAUSE:"pauseReplay",REPLAY_RUNNING:"replayRunning",ERROR_DURING_REPLAY:"errorDuringReplay"};n.g.ERROR,n.g.FULL,n.g.OFF},4234:(e,t,r)=>{"use strict";r.d(t,{W:()=>i});var n=r(7836);class i{constructor(e,t,r){this.agentIdentifier=e,this.aggregator=t,this.ee=n.ee.get(e),this.featureName=r,this.blocked=!1}}},2266:(e,t,r)=>{"use strict";r.d(t,{j:()=>k});var n=r(860),i=r(2983),o=r(9908),a=r(7836),s=r(1687),c=r(5289),u=r(6154),l=r(944),d=r(3969),g=r(384),f=r(6344);const h=["setErrorHandler","finished","addToTrace","addRelease","addPageAction","setCurrentRouteName","setPageViewName","setCustomAttribute","interaction","noticeError","setUserId","setApplicationVersion","start",f.G4.RECORD,f.G4.PAUSE,"log","wrapLogger"],p=["setErrorHandler","finished","addToTrace","addRelease"];var v=r(1863),m=r(2614),b=r(993);var y=r(2646),w=r(3434);function A(e,t,r,n){if("object"!=typeof t||!t||"string"!=typeof r||!r||"function"!=typeof t[r])return(0,l.R)(29);const i=function(e){return(e||a.ee).get("logger")}(e),o=(0,w.YM)(i),s=new y.y(a.P);return s.level=n.level,s.customAttributes=n.customAttributes,o.inPlace(t,[r],"wrap-logger-",s),i}function R(){const e=(0,g.pV)();h.forEach((t=>{e[t]=function(){for(var r=arguments.length,n=new Array(r),i=0;i<r;i++)n[i]=arguments[i];return function(t){for(var r=arguments.length,n=new Array(r>1?r-1:0),i=1;i<r;i++)n[i-1]=arguments[i];let o=[];return Object.values(e.initializedAgents).forEach((e=>{e&&e.api?e.exposed&&e.api[t]&&o.push(e.api[t](...n)):(0,l.R)(38,t)})),o.length>1?o:o[0]}(t,...n)}}))}const E={};function x(e,t){let g=arguments.length>2&&void 0!==arguments[2]&&arguments[2];t||(0,s.Ak)(e,"api");const h={};var y=a.ee.get(e),w=y.get("tracer");E[e]=m.g.OFF,y.on(f.G4.REPLAY_RUNNING,(t=>{E[e]=t}));var R="api-",x=R+"ixn-";function _(t,r,n,o){const a=(0,i.Vp)(e);return null===r?delete a.jsAttributes[t]:(0,i.x1)(e,{...a,jsAttributes:{...a.jsAttributes,[t]:r}}),k(R,n,!0,o||null===r?"session":void 0)(t,r)}function N(){}h.log=function(e){let{customAttributes:t={},level:r=b.p_.INFO}=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{};(0,o.p)(d.xV,["API/log/called"],void 0,n.K.metrics,y),function(e,t){let r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:{},i=arguments.length>3&&void 0!==arguments[3]?arguments[3]:b.p_.INFO;(0,o.p)(d.xV,["API/logging/".concat(i.toLowerCase(),"/called")],void 0,n.K.metrics,e),(0,o.p)(b.ET,[(0,v.t)(),t,r,i],void 0,n.K.logging,e)}(y,e,t,r)},h.wrapLogger=function(e,t){let{customAttributes:r={},level:i=b.p_.INFO}=arguments.length>2&&void 0!==arguments[2]?arguments[2]:{};(0,o.p)(d.xV,["API/wrapLogger/called"],void 0,n.K.metrics,y),A(y,e,t,{customAttributes:r,level:i})},p.forEach((e=>{h[e]=k(R,e,!0,"api")})),h.addPageAction=k(R,"addPageAction",!0,n.K.genericEvents),h.setPageViewName=function(t,r){if("string"==typeof t)return"/"!==t.charAt(0)&&(t="/"+t),(0,i.fr)(e).customTransaction=(r||"http://custom.transaction")+t,k(R,"setPageViewName",!0)()},h.setCustomAttribute=function(e,t){let r=arguments.length>2&&void 0!==arguments[2]&&arguments[2];if("string"==typeof e){if(["string","number","boolean"].includes(typeof t)||null===t)return _(e,t,"setCustomAttribute",r);(0,l.R)(40,typeof t)}else(0,l.R)(39,typeof e)},h.setUserId=function(e){if("string"==typeof e||null===e)return _("enduser.id",e,"setUserId",!0);(0,l.R)(41,typeof e)},h.setApplicationVersion=function(e){if("string"==typeof e||null===e)return _("application.version",e,"setApplicationVersion",!1);(0,l.R)(42,typeof e)},h.start=()=>{try{(0,o.p)(d.xV,["API/start/called"],void 0,n.K.metrics,y),y.emit("manual-start-all")}catch(e){(0,l.R)(23,e)}},h[f.G4.RECORD]=function(){(0,o.p)(d.xV,["API/recordReplay/called"],void 0,n.K.metrics,y),(0,o.p)(f.G4.RECORD,[],void 0,n.K.sessionReplay,y)},h[f.G4.PAUSE]=function(){(0,o.p)(d.xV,["API/pauseReplay/called"],void 0,n.K.metrics,y),(0,o.p)(f.G4.PAUSE,[],void 0,n.K.sessionReplay,y)},h.interaction=function(e){return(new N).get("object"==typeof e?e:{})};const T=N.prototype={createTracer:function(e,t){var r={},i=this,a="function"==typeof t;return(0,o.p)(d.xV,["API/createTracer/called"],void 0,n.K.metrics,y),g||(0,o.p)(x+"tracer",[(0,v.t)(),e,r],i,n.K.spa,y),function(){if(w.emit((a?"":"no-")+"fn-start",[(0,v.t)(),i,a],r),a)try{return t.apply(this,arguments)}catch(e){const t="string"==typeof e?new Error(e):e;throw w.emit("fn-err",[arguments,this,t],r),t}finally{w.emit("fn-end",[(0,v.t)()],r)}}}};function k(e,t,r,i){return function(){return(0,o.p)(d.xV,["API/"+t+"/called"],void 0,n.K.metrics,y),i&&(0,o.p)(e+t,[(0,v.t)(),...arguments],r?null:this,i,y),r?void 0:this}}function S(){r.e(296).then(r.bind(r,8778)).then((t=>{let{setAPI:r}=t;r(e),(0,s.Ze)(e,"api")})).catch((e=>{(0,l.R)(27,e),y.abort()}))}return["actionText","setName","setAttribute","save","ignore","onEnd","getContext","end","get"].forEach((e=>{T[e]=k(x,e,void 0,g?n.K.softNav:n.K.spa)})),h.setCurrentRouteName=g?k(x,"routeName",void 0,n.K.softNav):k(R,"routeName",!0,n.K.spa),h.noticeError=function(t,r){"string"==typeof t&&(t=new Error(t)),(0,o.p)(d.xV,["API/noticeError/called"],void 0,n.K.metrics,y),(0,o.p)("err",[t,(0,v.t)(),!1,r,!!E[e]],void 0,n.K.jserrors,y)},u.RI?(0,c.GG)((()=>S()),!0):S(),h}var _=r(5284);const N=e=>{const t=e.startsWith("http");e+="/",r.p=t?e:"https://"+e};let T=!1;function k(e){let t=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{},r=arguments.length>2?arguments[2]:void 0,n=arguments.length>3?arguments[3]:void 0,{init:o,info:s,loader_config:c,runtime:l={},exposed:d=!0}=t;l.loaderType=r;const f=(0,g.pV)();s||(o=f.init,s=f.info,c=f.loader_config),(0,i.xN)(e.agentIdentifier,o||{}),(0,i.aN)(e.agentIdentifier,c||{}),s.jsAttributes??={},u.bv&&(s.jsAttributes.isWorker=!0),(0,i.x1)(e.agentIdentifier,s);const h=(0,i.D0)(e.agentIdentifier),p=[s.beacon,s.errorBeacon];T||(h.proxy.assets&&(N(h.proxy.assets),p.push(h.proxy.assets)),h.proxy.beacon&&p.push(h.proxy.beacon),R(),(0,g.US)("activatedFeatures",_.B),e.runSoftNavOverSpa&&=!0===h.soft_navigations.enabled&&h.feature_flags.includes("soft_nav")),l.denyList=[...h.ajax.deny_list||[],...h.ajax.block_internal?p:[]],l.ptid=e.agentIdentifier,(0,i.V)(e.agentIdentifier,l),e.ee=a.ee.get(e.agentIdentifier),void 0===e.api&&(e.api=x(e.agentIdentifier,n,e.runSoftNavOverSpa)),void 0===e.exposed&&(e.exposed=d),T=!0}},8374:(e,t,r)=>{r.nc=(()=>{try{return document?.currentScript?.nonce}catch(e){}return""})()},860:(e,t,r)=>{"use strict";r.d(t,{K:()=>n,P:()=>i});const n={ajax:"ajax",genericEvents:"generic_events",jserrors:"jserrors",logging:"logging",metrics:"metrics",pageAction:"page_action",pageViewEvent:"page_view_event",pageViewTiming:"page_view_timing",sessionReplay:"session_replay",sessionTrace:"session_trace",softNav:"soft_navigations",spa:"spa"},i={[n.pageViewEvent]:1,[n.pageViewTiming]:2,[n.metrics]:3,[n.jserrors]:4,[n.spa]:5,[n.ajax]:6,[n.sessionTrace]:7,[n.softNav]:8,[n.sessionReplay]:9,[n.logging]:10,[n.genericEvents]:11}}},n={};function i(e){var t=n[e];if(void 0!==t)return t.exports;var o=n[e]={exports:{}};return r[e](o,o.exports,i),o.exports}i.m=r,i.d=(e,t)=>{for(var r in t)i.o(t,r)&&!i.o(e,r)&&Object.defineProperty(e,r,{enumerable:!0,get:t[r]})},i.f={},i.e=e=>Promise.all(Object.keys(i.f).reduce(((t,r)=>(i.f[r](e,t),t)),[])),i.u=e=>"nr-rum-1.264.0.min.js",i.o=(e,t)=>Object.prototype.hasOwnProperty.call(e,t),e={},t="NRBA-1.264.0.PROD:",i.l=(r,n,o,a)=>{if(e[r])e[r].push(n);else{var s,c;if(void 0!==o)for(var u=document.getElementsByTagName("script"),l=0;l<u.length;l++){var d=u[l];if(d.getAttribute("src")==r||d.getAttribute("data-webpack")==t+o){s=d;break}}if(!s){c=!0;var g={296:"sha512-/JFTCbNPZPe6tX1oowGTDXgTXJPZczBrsUMXw4/4Iz7c/U06sSfloejUIdps4/XHjV4Xx4uaRdele2Dq0BHQlw=="};(s=document.createElement("script")).charset="utf-8",s.timeout=120,i.nc&&s.setAttribute("nonce",i.nc),s.setAttribute("data-webpack",t+o),s.src=r,0!==s.src.indexOf(window.location.origin+"/")&&(s.crossOrigin="anonymous"),g[a]&&(s.integrity=g[a])}e[r]=[n];var f=(t,n)=>{s.onerror=s.onload=null,clearTimeout(h);var i=e[r];if(delete e[r],s.parentNode&&s.parentNode.removeChild(s),i&&i.forEach((e=>e(n))),t)return t(n)},h=setTimeout(f.bind(null,void 0,{type:"timeout",target:s}),12e4);s.onerror=f.bind(null,s.onerror),s.onload=f.bind(null,s.onload),c&&document.head.appendChild(s)}},i.r=e=>{"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(e,"__esModule",{value:!0})},i.p="https://js-agent.newrelic.com/",(()=>{var e={840:0,374:0};i.f.j=(t,r)=>{var n=i.o(e,t)?e[t]:void 0;if(0!==n)if(n)r.push(n[2]);else{var o=new Promise(((r,i)=>n=e[t]=[r,i]));r.push(n[2]=o);var a=i.p+i.u(t),s=new Error;i.l(a,(r=>{if(i.o(e,t)&&(0!==(n=e[t])&&(e[t]=void 0),n)){var o=r&&("load"===r.type?"missing":r.type),a=r&&r.target&&r.target.src;s.message="Loading chunk "+t+" failed.\n("+o+": "+a+")",s.name="ChunkLoadError",s.type=o,s.request=a,n[1](s)}}),"chunk-"+t,t)}};var t=(t,r)=>{var n,o,[a,s,c]=r,u=0;if(a.some((t=>0!==e[t]))){for(n in s)i.o(s,n)&&(i.m[n]=s[n]);if(c)c(i)}for(t&&t(r);u<a.length;u++)o=a[u],i.o(e,o)&&e[o]&&e[o][0](),e[o]=0},r=self["webpackChunk:NRBA-1.264.0.PROD"]=self["webpackChunk:NRBA-1.264.0.PROD"]||[];r.forEach(t.bind(null,0)),r.push=t.bind(null,r.push.bind(r))})(),(()=>{"use strict";i(8374);var e=i(944),t=i(6344),r=i(9566);class n{agentIdentifier;constructor(){let e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:(0,r.LA)(16);this.agentIdentifier=e}#e(t){for(var r=arguments.length,n=new Array(r>1?r-1:0),i=1;i<r;i++)n[i-1]=arguments[i];if("function"==typeof this.api?.[t])return this.api[t](...n);(0,e.R)(35,t)}addPageAction(e,t){return this.#e("addPageAction",e,t)}setPageViewName(e,t){return this.#e("setPageViewName",e,t)}setCustomAttribute(e,t,r){return this.#e("setCustomAttribute",e,t,r)}noticeError(e,t){return this.#e("noticeError",e,t)}setUserId(e){return this.#e("setUserId",e)}setApplicationVersion(e){return this.#e("setApplicationVersion",e)}setErrorHandler(e){return this.#e("setErrorHandler",e)}finished(e){return this.#e("finished",e)}addRelease(e,t){return this.#e("addRelease",e,t)}start(e){return this.#e("start",e)}recordReplay(){return this.#e(t.G4.RECORD)}pauseReplay(){return this.#e(t.G4.PAUSE)}addToTrace(e){return this.#e("addToTrace",e)}setCurrentRouteName(e){return this.#e("setCurrentRouteName",e)}interaction(){return this.#e("interaction")}log(e,t){return this.#e("logInfo",e,t)}wrapLogger(e,t,r){return this.#e("wrapLogger",e,t,r)}}var o=i(860),a=i(2983);const s=Object.values(o.K);function c(e){const t={};return s.forEach((r=>{t[r]=function(e,t){return!0===(0,a.gD)(t,"".concat(e,".enabled"))}(r,e)})),t}var u=i(2266);var l=i(1687),d=i(4234),g=i(5289),f=i(6154);const h=e=>f.RI&&!0===(0,a.gD)(e,"privacy.cookies_enabled");function p(e){return!!a.hR.MO&&h(e)&&!0===(0,a.gD)(e,"session_trace.enabled")}var v=i(6389);class m extends d.W{constructor(e,t,r){let n=!(arguments.length>3&&void 0!==arguments[3])||arguments[3];super(e,t,r),this.auto=n,this.abortHandler=void 0,this.featAggregate=void 0,this.onAggregateImported=void 0,!1===(0,a.gD)(this.agentIdentifier,"".concat(this.featureName,".autoStart"))&&(this.auto=!1),this.auto?(0,l.Ak)(e,r):this.ee.on("manual-start-all",(0,v.J)((()=>{(0,l.Ak)(this.agentIdentifier,this.featureName),this.auto=!0,this.importAggregator()})))}importAggregator(){let t,r=arguments.length>0&&void 0!==arguments[0]?arguments[0]:{};if(this.featAggregate||!this.auto)return;this.onAggregateImported=new Promise((e=>{t=e}));const n=async()=>{let n;try{if(h(this.agentIdentifier)){const{setupAgentSession:e}=await i.e(296).then(i.bind(i,2987));n=e(this.agentIdentifier)}}catch(t){(0,e.R)(20,t),this.ee.emit("internal-error",[t]),this.featureName===o.K.sessionReplay&&this.abortHandler?.()}try{if(!this.#t(this.featureName,n))return(0,l.Ze)(this.agentIdentifier,this.featureName),void t(!1);const{lazyFeatureLoader:e}=await i.e(296).then(i.bind(i,6103)),{Aggregate:o}=await e(this.featureName,"aggregate");this.featAggregate=new o(this.agentIdentifier,this.aggregator,r),t(!0)}catch(r){(0,e.R)(34,r),this.abortHandler?.(),(0,l.Ze)(this.agentIdentifier,this.featureName,!0),t(!1),this.ee&&this.ee.abort()}};f.RI?(0,g.GG)((()=>n()),!0):n()}#t(e,t){switch(e){case o.K.sessionReplay:return p(this.agentIdentifier)&&!!t;case o.K.sessionTrace:return!!t;default:return!0}}}var b=i(6630);class y extends m{static featureName=(()=>b.T)();constructor(e,t){let r=!(arguments.length>2&&void 0!==arguments[2])||arguments[2];super(e,t,b.T,r),this.importAggregator()}}var w=i(4777);class A extends w.J{constructor(e){super(e),this.aggregatedData={}}store(e,t,r,n,i){var o=this.getBucket(e,t,r,i);return o.metrics=function(e,t){t||(t={count:0});return t.count+=1,Object.entries(e||{}).forEach((e=>{let[r,n]=e;t[r]=R(n,t[r])})),t}(n,o.metrics),o}merge(e,t,r,n,i){var o=this.getBucket(e,t,n,i);if(o.metrics){var a=o.metrics;a.count+=r.count,Object.keys(r||{}).forEach((e=>{if("count"!==e){var t=a[e],n=r[e];n&&!n.c?a[e]=R(n.t,t):a[e]=function(e,t){if(!t)return e;t.c||(t=E(t.t));return t.min=Math.min(e.min,t.min),t.max=Math.max(e.max,t.max),t.t+=e.t,t.sos+=e.sos,t.c+=e.c,t}(n,a[e])}}))}else o.metrics=r}storeMetric(e,t,r,n){var i=this.getBucket(e,t,r);return i.stats=R(n,i.stats),i}getBucket(e,t,r,n){this.aggregatedData[e]||(this.aggregatedData[e]={});var i=this.aggregatedData[e][t];return i||(i=this.aggregatedData[e][t]={params:r||{}},n&&(i.custom=n)),i}get(e,t){return t?this.aggregatedData[e]&&this.aggregatedData[e][t]:this.aggregatedData[e]}take(e){for(var t={},r="",n=!1,i=0;i<e.length;i++)t[r=e[i]]=Object.values(this.aggregatedData[r]||{}),t[r].length&&(n=!0),delete this.aggregatedData[r];return n?t:null}}function R(e,t){return null==e?function(e){e?e.c++:e={c:1};return e}(t):t?(t.c||(t=E(t.t)),t.c+=1,t.t+=e,t.sos+=e*e,e>t.max&&(t.max=e),e<t.min&&(t.min=e),t):{t:e}}function E(e){return{t:e,min:e,max:e,sos:e*e,c:1}}var x=i(384);var _=i(9908),N=i(2843),T=i(3878),k=i(782),S=i(1863);class j extends m{static featureName=(()=>k.T)();constructor(e,t){let r=!(arguments.length>2&&void 0!==arguments[2])||arguments[2];super(e,t,k.T,r),f.RI&&((0,N.u)((()=>(0,_.p)("docHidden",[(0,S.t)()],void 0,k.T,this.ee)),!0),(0,T.sp)("pagehide",(()=>(0,_.p)("winPagehide",[(0,S.t)()],void 0,k.T,this.ee))),this.importAggregator())}}var I=i(3969);class O extends m{static featureName=(()=>I.TZ)();constructor(e,t){let r=!(arguments.length>2&&void 0!==arguments[2])||arguments[2];super(e,t,I.TZ,r),this.importAggregator()}}new class extends n{constructor(t,r){super(r),f.gm?(this.sharedAggregator=new A({agentIdentifier:this.agentIdentifier}),this.features={},(0,x.bQ)(this.agentIdentifier,this),this.desiredFeatures=new Set(t.features||[]),this.desiredFeatures.add(y),this.runSoftNavOverSpa=[...this.desiredFeatures].some((e=>e.featureName===o.K.softNav)),(0,u.j)(this,t,t.loaderType||"agent"),this.run()):(0,e.R)(21)}get config(){return{info:this.info,init:this.init,loader_config:this.loader_config,runtime:this.runtime}}run(){try{const t=c(this.agentIdentifier),r=[...this.desiredFeatures];r.sort(((e,t)=>o.P[e.featureName]-o.P[t.featureName])),r.forEach((r=>{if(!t[r.featureName]&&r.featureName!==o.K.pageViewEvent)return;if(this.runSoftNavOverSpa&&r.featureName===o.K.spa)return;if(!this.runSoftNavOverSpa&&r.featureName===o.K.softNav)return;(function(e){switch(e){case o.K.ajax:return[o.K.jserrors];case o.K.sessionTrace:return[o.K.ajax,o.K.pageViewEvent];case o.K.sessionReplay:return[o.K.sessionTrace];case o.K.pageViewTiming:return[o.K.pageViewEvent];default:return[]}})(r.featureName).every((e=>e in this.features))||(0,e.R)(36,r.featureName),this.features[r.featureName]=new r(this.agentIdentifier,this.sharedAggregator)}))}catch(t){(0,e.R)(22,t);for(const e in this.features)this.features[e].abortHandler?.();const r=(0,x.Zm)();delete r.initializedAgents[this.agentIdentifier]?.api,delete r.initializedAgents[this.agentIdentifier]?.features,delete this.sharedAggregator;return r.ee.get(this.agentIdentifier).abort(),!1}}}({features:[y,j,O],loaderType:"lite"})})()})();</script>
+<link rel="canonical" href="https://www.pitt.edu/pittwire/news/features-articles" />
+<meta property="og:site_name" content="University of Pittsburgh" />
+<meta property="og:type" content="website" />
+<meta property="og:url" content="https://www.pitt.edu/pittwire/news/features-articles" />
+<meta property="og:title" content="Pittwire News" />
+<meta name="MobileOptimized" content="width" />
+<meta name="HandheldFriendly" content="true" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<script type="application/ld+json">{
+    "@context": "https://schema.org",
+    "@graph": [
+        {
+            "@type": "Organization",
+            "@id": "https://www.pitt.edu/",
+            "name": "University of Pittsburgh",
+            "url": "https://www.pitt.edu/"
+        }
+    ]
+}</script>
+<link rel="icon" href="/sites/default/files/favicon.ico" type="image/vnd.microsoft.icon" />
+
+    <title>Pittwire News | University of Pittsburgh</title>
+    <link rel="stylesheet" media="all" href="/core/modules/system/css/components/ajax-progress.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/align.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/autocomplete-loading.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/fieldgroup.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/container-inline.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/clearfix.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/details.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/hidden.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/item-list.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/js.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/nowrap.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/position-container.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/progress.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/reset-appearance.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/resize.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/sticky-header.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/system-status-counter.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/system-status-report-counters.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/system-status-report-general-info.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/tabledrag.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/tablesort.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/system/css/components/tree-child.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/media/css/oembed.formatter.css?shklz9" />
+<link rel="stylesheet" media="all" href="/core/modules/views/css/views.module.css?shklz9" />
+<link rel="stylesheet" media="all" href="/sites/default/files/micon/fa/style.css?shklz9" />
+<link rel="stylesheet" media="all" href="/modules/contrib/social_media_links/css/social_media_links.theme.css?shklz9" />
+<link rel="stylesheet" media="all" href="/modules/contrib/extlink/extlink.css?shklz9" />
+<link rel="stylesheet" media="all" href="/modules/contrib/paragraphs/css/paragraphs.unpublished.css?shklz9" />
+<link rel="stylesheet" media="all" href="/modules/contrib/better_exposed_filters/css/better_exposed_filters.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/global-styles.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/navigation.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/hero-banner.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/content-well.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/template-layout-mixin.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/collapse.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/footer-override.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/button.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/breadcrumb.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/cse.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/overrides.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/pittmag.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/contrib/zensource_front_end/css/components/hero-placeholder.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/contrib/zensource_front_end/css/classy/components/messages.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/contrib/zensource_front_end/css/classy/components/details.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/contrib/zenny/css/classy/components/pager.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/card.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/contrib/zensource_front_end/css/components/entity-overlay.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/media-item.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/pagination.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/choices.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/form.css?shklz9" />
+<link rel="stylesheet" media="all" href="/themes/custom/pitt_default/css/modal.css?shklz9" />
+
+
+	<!-- Google Tag Manager -->
+	<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+	new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+	j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+	'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+	})(window,document,'script','dataLayer','GTM-NXCGL72');</script>
+	<!-- End Google Tag Manager -->
+
+  <script async src="https://cse.google.com/cse.js?cx=013753980878518964357:mgrjnoukllc"></script>
+
+  </head>
+  <body class="path-pittwire">
+	<!-- Google Tag Manager (noscript) -->
+	<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NXCGL72"
+	height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+	<!-- End Google Tag Manager (noscript) -->
+
+        <a href="#main-content" class="visually-hidden focusable skip-link">
+      Skip to main content
+    </a>
+
+      <div class="dialog-off-canvas-main-canvas" data-off-canvas-main-canvas>
+
+
+        <div id="block-pitt-pittwire-sitebranding" class="block block-system block-system-branding-block">
+
+
+  <!-- global nav -->
+<div class="header-wrapper" role="region" aria-label="Navigation area">
+<header class="header pitt-wire">
+  <div class="header-container">
+    <div class="header-grid">
+      <div class="pitt-wire-nav">
+        <div class="logo">
+                      <div class="logo-pitt"><a href="/"><img src="/themes/custom/pitt_pittwire/logo.svg" alt="University of Pittsburgh"></a></div>
+            <div class="logo-pitt print-only"><img src="/themes/custom/pitt_pittwire/logo-print.png" alt="UPitt Logo"></div>
+                    <div class="logo-pitt-wire"><a href="/pittwire"><img src="/themes/custom/pitt_pittwire/logo-pittwire.svg" alt="Pitt Wire"></a></div>
+          <div class="logo-pitt-wire print-only"><img src="/themes/custom/pitt_pittwire/logo-pittwire-print.png" alt="Pitt Wire"></div>
+        </div>
+        <div class="explore-sections"><button class="" data-toggle="modal" data-target="#pitt-wire-menu" data-gtm="">Explore Sections</button></div>
+      </div>
+      <!-- main navigation -->
+      <div class="navigation" role="navigation" aria-label="Mega Menu">
+        <ul class="navigation-button-wrapper">
+          <li>
+            <button type="button" class="navigation-button" data-toggle="modal" data-target="#pittwire-search-menu" data-gtm="">
+              <span class="sr-only">open search</span>
+              <span class="icon-search"></span>
+            </button>
+          </li>
+          <li>
+            <button type="button" class="navigation-button" data-toggle="modal" data-target="#hamburger-menu" data-gtm="">
+              <span class="sr-only">open menu</span>
+              <span class="icon-hamburger"></span>
+            </button>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</header>
+</div>
+</div>
+
+
+<div id="pitt-wire-menu" class="modal modal--side navigation-slide-menu left pitt-wire-menu" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <!-- modal - header -->
+      <div class="modal-header">
+        <!-- modal - dismiss -->
+        <button type="button" class="modal-dismiss-button" data-dismiss="modal" aria-label="Close" data-gtm="">
+          <span class="sr-only">Close</span>
+        </button>
+      </div>
+      <!-- modal - body -->
+      <div class="modal-body">
+               	        <p class="field field--type-string-long field--label-hidden field__item">
+	  	  From the latest big breakthrough to the most influential and inspiring figures on campus to Pitt in the community, Pittwire is your official source for what’s happening now.
+	  	  </p>
+
+        <div class="hamburger-menu-wrapper">
+          <div class="hamburger-menu-upper">
+            <div id="block-pittwireexploretopics" class="hamburger-menu-upper-column block block-menu menu--pittwire-explore-topics">
+    <div class="hamburger-menu-header">Explore Sections</div>
+
+
+
+                <ul class="hamburger-menu-list">
+                    <li>
+                <a href="/pittwire/health-and-wellness" data-drupal-link-system-path="node/21">Health and Wellness</a>
+            </li>
+                    <li>
+                <a href="/pittwire/technology-and-science" data-drupal-link-system-path="node/13546">Technology and Science</a>
+            </li>
+                    <li>
+                <a href="/pittwire/arts-and-humanities" data-drupal-link-system-path="node/13547">Arts and Humanities</a>
+            </li>
+                    <li>
+                <a href="/pittwire/community-impact" data-drupal-link-system-path="node/13548">Community Impact</a>
+            </li>
+                    <li>
+                <a href="/pittwire/diversity-equity-and-inclusion" data-drupal-link-system-path="node/13551">Diversity, Equity, and Inclusion</a>
+            </li>
+                    <li>
+                <a href="/pittwire/global" data-drupal-link-system-path="node/13550">Global</a>
+            </li>
+                    <li>
+                <a href="/pittwire/innovation-and-research" data-drupal-link-system-path="node/13549">Innovation and Research</a>
+            </li>
+                    <li>
+                <a href="/pittwire/our-cityour-campus" data-drupal-link-system-path="node/13552">Our City/Our Campus</a>
+            </li>
+                    <li>
+                <a href="/pittwire/pittmagazine" data-drupal-link-system-path="pittwire/pittmagazine">Pitt Magazine</a>
+            </li>
+                </ul>
+
+
+
+    </div>
+            <div class="views-element-container hamburger-menu-upper-column block block-views block-views-blockcategory-menu-category-menu" id="block-views-block-category-menu-category-menu">
+            <div class="hamburger-menu-header">Explore By Category</div>
+                <div><div class="view view-category-menu view-id-category_menu view-display-id-category_menu js-view-dom-id-b170f5273de9e49d338bd391911f15a452a1aad3165e79a0130dcec5844e7ea5">
+
+
+
+      <div class="view-content">
+      <ul class="hamburger-menu-list">
+            <li><div class="views-field views-field-name"><span class="field-content"><a href="/pittwire/news/features-articles">Features &amp; Articles</a></span></div></li>
+            <li><div class="views-field views-field-name"><span class="field-content"><a href="/pittwire/news/accolades-honors">Accolades &amp; Honors</a></span></div></li>
+            <li><div class="views-field views-field-name"><span class="field-content"><a href="/pittwire/news/ones-to-watch">Ones to Watch</a></span></div></li>
+            <li><div class="views-field views-field-name"><span class="field-content"><a href="/pittwire/news/announcements-and-updates">Announcements and Updates</a></span></div></li>
+    </ul>
+
+    </div>
+
+          </div>
+</div>
+
+
+    <nav role="navigation" aria-labelledby="block-pittwireotherlinks-menu" id="block-pittwireotherlinks" class="block block-menu navigation menu--pittwire-other-links">
+
+  <h2 class="visually-hidden" id="block-pittwireotherlinks-menu">Pittwire Other Links</h2>
+
+
+
+<ul class="hamburger-menu-main">
+            <li>
+            <a href="https://calendar.pitt.edu/" target="_blank">Event Calendar</a>
+        </li>
+            <li>
+            <a href="https://www.pitt.edu/social" target="_blank">Social Media Directory</a>
+        </li>
+    </ul>
+
+
+
+  </nav>
+
+</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="search-menu" class="modal modal--side navigation-slide-menu right" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <!-- modal - header -->
+      <div class="modal-header">
+        <!-- modal - dismiss -->
+        <button type="button" class="modal-dismiss-button" data-dismiss="modal" aria-label="Close" data-gtm="">
+          <span class="sr-only">Close</span>
+        </button>
+      </div>
+      <!-- modal - body -->
+      <div class="modal-body">
+        <div class="search-menu-wrapper">
+          <div class="search-menu-header">Search Pitt</div>
+
+          <div class="search-menu-typeahead-wrapper">
+            <div class="search-menu-typeahead">
+              <label for="main-search-nav" class="sr-only">Search</label>
+
+              <!-- cse markup -->
+              <div class="gcse-searchbox-only" data-enableHistory="true" data-autoCompleteMaxCompletions="5" data-autoCompleteMatchType="any" data-resultsUrl="search-results"></div>
+
+            </div>
+
+          </div>
+
+
+          <div class="search-menu-footer">
+            <a href="https://find.pitt.edu" class="arrow">Search for People</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<div id="hamburger-menu" class="modal modal--side navigation-slide-menu right" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <!-- modal - header -->
+      <div class="modal-header">
+        <!-- modal - dismiss -->
+        <button type="button" class="modal-dismiss-button" data-dismiss="modal" aria-label="Close" data-gtm="">
+          <span class="sr-only">Close</span>
+        </button>
+      </div>
+      <!-- modal - body -->
+      <div class="modal-body">
+        <div class="hamburger-menu-wrapper">
+                      <div id="block-hamburgermenuupper-2" class="hamburger-menu-upper block block-blockgroup block-block-grouphamburger-menu-upper">
+
+
+      <div id="block-hamburgermenuuppercolumn1" class="hamburger-menu-upper-column block block-blockgroup block-block-grouphamburger-menu-upper-column-1">
+
+
+      <nav role="navigation" aria-labelledby="block-globalmenu-3-menu" id="block-globalmenu-3" class="block block-menu navigation menu--global-menu">
+
+  <h2 class="visually-hidden" id="block-globalmenu-3-menu">Global Menu</h2>
+
+
+
+        <ul class="hamburger-menu-main">
+          <li>
+	  <a href="https://admissions.pitt.edu/apply/" class="data-gtm-utilityNavKPI" data-contentTitle="Apply">Apply</a>
+      </li>
+          <li>
+	  <a href="https://admissions.pitt.edu/visit/unscripted/" class="data-gtm-utilityNavKPI" data-contentTitle="Visit">Visit</a>
+      </li>
+          <li>
+	  <a href="https://www.giveto.pitt.edu/s/1729/18/home-giving.aspx?gid=2&amp;pgid=2135" class="data-gtm-utilityNavKPI" data-contentTitle="Give">Give</a>
+      </li>
+          <li>
+	  <a href="/pittwire" class="data-gtm-utilityNavKPI" data-contentTitle="Pittwire">Pittwire</a>
+      </li>
+          <li>
+	  <a href="http://calendar.pitt.edu/" class="data-gtm-utilityNavKPI" data-contentTitle="Events">Events</a>
+      </li>
+        </ul>
+
+
+
+  </nav>
+      <button is="menu-blockmain-btn" class="collapse-trigger--md collapsed hamburger-menu-header-btn" role="tab" data-toggle="collapse" data-target="#menu-blockmain" aria-expanded="false" aria-controls="menu-blockmain" data-gtm="">Navigation</button>
+<div class="collapse-target--md collapse" id="menu-blockmain" role="tabpanel" aria-labelledby="menu-blockmain-btn">
+
+
+  <div  id="block-navigation-2-menu" class="hamburger-menu-header">Navigation</div>
+
+
+
+        <ul class="hamburger-menu-list">
+          <li>
+		<a href="/about" class="data-gtm-utilityNavCategory" data-contentTitle="About">About</a>
+      </li>
+          <li>
+		<a href="/academics" class="data-gtm-utilityNavCategory" data-contentTitle="Academics">Academics</a>
+      </li>
+          <li>
+		<a href="/admissions" class="data-gtm-utilityNavCategory" data-contentTitle="Admissions">Admissions</a>
+      </li>
+          <li>
+		<a href="/research" class="data-gtm-utilityNavCategory" data-contentTitle="Research">Research</a>
+      </li>
+          <li>
+		<a href="/student-life" class="data-gtm-utilityNavCategory" data-contentTitle="Life at Pitt">Life at Pitt</a>
+      </li>
+          <li>
+		<a href="http://pittsburghpanthers.com/" class="data-gtm-utilityNavCategory" data-contentTitle="Athletics">Athletics</a>
+      </li>
+        </ul>
+
+
+
+  </div>
+
+  </div>
+<div id="block-hamburgermenuuppercolumn2" class="hamburger-menu-upper-column block block-blockgroup block-block-grouphamburger-menu-upper-">
+
+
+            <button is="menu-blockquick-links-3-btn" class="collapse-trigger--md collapsed hamburger-menu-header-btn" role="tab" data-toggle="collapse" data-target="#menu-blockquick-links-3" aria-expanded="false" aria-controls="menu-blockquick-links-3" data-gtm="">Colleges &amp; Schools</button>
+<div class="collapse-target--md collapse" id="menu-blockquick-links-3" role="tabpanel" aria-labelledby="menu-blockquick-links-3-btn">
+
+
+  <div  id="block-collegesschools-2-menu" class="hamburger-menu-header">Colleges &amp; Schools</div>
+
+
+
+        <ul class="hamburger-menu-list">
+          <li>
+		<a href="https://www.as.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Arts &amp; Sciences">Arts &amp; Sciences</a>
+      </li>
+          <li>
+		<a href="https://www.business.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Business">Business</a>
+      </li>
+          <li>
+		<a href="https://www.sci.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Computing &amp; Information">Computing &amp; Information</a>
+      </li>
+          <li>
+		<a href="https://www.dental.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Dental Medicine">Dental Medicine</a>
+      </li>
+          <li>
+		<a href="https://www.education.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Education">Education</a>
+      </li>
+          <li>
+		<a href="https://www.engineering.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Engineering">Engineering</a>
+      </li>
+          <li>
+		<a href="https://www.cgs.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="General Studies">General Studies</a>
+      </li>
+          <li>
+		<a href="https://www.shrs.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Health &amp; Rehabilitation">Health &amp; Rehabilitation</a>
+      </li>
+          <li>
+		<a href="https://www.honors.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Honors College">Honors College</a>
+      </li>
+          <li>
+		<a href="https://www.law.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Law">Law</a>
+      </li>
+          <li>
+		<a href="https://www.medschool.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Medicine">Medicine</a>
+      </li>
+          <li>
+		<a href="https://www.nursing.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Nursing">Nursing</a>
+      </li>
+          <li>
+		<a href="https://www.pharmacy.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Pharmacy">Pharmacy</a>
+      </li>
+          <li>
+		<a href="https://www.gspia.pitt.edu" class="data-gtm-utilityNavCategory" data-contentTitle="Public &amp; Intl Affairs">Public &amp; Intl Affairs</a>
+      </li>
+          <li>
+		<a href="https://publichealth.pitt.edu/" class="data-gtm-utilityNavCategory" data-contentTitle="Public Health">Public Health</a>
+      </li>
+          <li>
+		<a href="https://www.socialwork.pitt.edu/" class="data-gtm-utilityNavCategory" data-contentTitle="Social Work">Social Work</a>
+      </li>
+        </ul>
+
+
+
+  </div>
+
+  </div>
+
+  </div>
+<div id="block-hamburgermenulower" class="hamburger-menu-lower block block-blockgroup block-block-grouphamburger-menu-lower">
+
+
+      <div id="block-hamburgermenulowercolumn1" class="hamburger-menu-lower-column block block-blockgroup block-block-grouphamburger-menu-lower-column-1">
+
+
+            <button is="menu-blockinfo-menu-btn" class="collapse-trigger--md collapsed hamburger-menu-header-btn" role="tab" data-toggle="collapse" data-target="#menu-blockinfo-menu" aria-expanded="false" aria-controls="menu-blockinfo-menu" data-gtm="">Info For</button>
+<div class="collapse-target--md collapse" id="menu-blockinfo-menu" role="tabpanel" aria-labelledby="menu-blockinfo-menu-btn">
+
+
+  <div  id="block-infomenu-2-menu" class="hamburger-menu-header">Info For</div>
+
+
+
+            <ul class="hamburger-menu-list">
+      <li class="hamburger-menu-list-wrapper">
+        <ul class="hamburger-menu-list">
+                              <li>
+			<a href="http://coronavirus.pitt.edu/" class="data-gtm-utilityNavCategory" data-contentTitle="COVID-19 Response">COVID-19 Response</a>
+            </li>
+                                        <li>
+			<a href="https://www.alumni.pitt.edu/s/1729/alumni/home.aspx?gid=2&amp;pgid=2381" class="data-gtm-utilityNavCategory" data-contentTitle="Alumni">Alumni</a>
+            </li>
+                                                                                </ul>
+        <ul class="hamburger-menu-list">
+                                                                  <li>
+			<a href="https://www.community.pitt.edu/" class="data-gtm-utilityNavCategory" data-contentTitle="Community">Community</a>
+            </li>
+                                        <li>
+			<a href="/global" class="data-gtm-utilityNavCategory" data-contentTitle="Global">Global</a>
+            </li>
+                                        <li>
+			<a href="https://www.sustainable.pitt.edu/" class="data-gtm-utilityNavCategory" data-contentTitle="Sustainability">Sustainability</a>
+            </li>
+                          </ul>
+      </li>
+    </ul>
+
+
+
+
+  </div>
+
+  </div>
+<div id="block-hamburgermenulowercolumn2" class="hamburger-menu-lower-column block block-blockgroup block-block-grouphamburger-menu-lower-column-2">
+
+
+      <div id="block-socialmedialinks-4" class="hamburger-menu-social block-social-media-links block block-social-media-links-block">
+
+
+
+
+<ul class="social-media-links--platforms platforms inline horizontal">
+      <li>
+      <a class="social-media-link-icon--twitter" href="https://www.twitter.com/PittTweet"  >
+          <i class="micon fa-twitter" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Twitter</span>
+      </a>
+    </li>
+      <li>
+      <a class="social-media-link-icon--instagram" href="https://www.instagram.com/pittofficial"  >
+          <i class="micon fa-instagram" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Instagram</span>
+      </a>
+    </li>
+      <li>
+      <a class="social-media-link-icon--facebook" href="https://www.facebook.com/upitt"  >
+          <i class="micon fa-facebook" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Facebook</span>
+      </a>
+    </li>
+      <li>
+      <a class="social-media-link-icon--youtube" href="https://www.youtube.com/user/pittweb"  >
+          <i class="micon fa-youtube" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Youtube</span>
+      </a>
+    </li>
+  </ul>
+
+  </div>
+
+  </div>
+
+  </div>
+
+                  </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="pittwire-search-menu" class="modal modal--side navigation-slide-menu right" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <!-- modal - header -->
+      <div class="modal-header">
+        <!-- modal - dismiss -->
+        <button type="button" class="modal-dismiss-button" data-dismiss="modal" aria-label="Close" data-gtm="">
+          <span class="sr-only">Close</span>
+        </button>
+      </div>
+      <!-- modal - body -->
+      <div class="modal-body">
+        <div class="search-menu-wrapper">
+          <div class="search-menu-header">Search Pittwire</div>
+
+          <div class="search-menu-typeahead-wrapper">
+            <div class="search-menu-typeahead">
+              <label for="main-search-nav" class="sr-only">Search</label>
+
+              <!-- cse markup -->
+              <div class="gcse-searchbox-only" data-enableHistory="true" data-autoCompleteMaxCompletions="5" data-autoCompleteMatchType="any" data-resultsUrl="/pittwire/search-results"></div>
+
+            </div>
+
+          </div>
+
+
+          <div class="search-menu-footer">
+            <a href="https://www.pitt.edu/search-results" class="arrow">Search www.pitt.edu</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+<main id="content" class="main-container">
+    <a id="main-content" tabindex="-1"></a>
+    <div class="layout--right-rail pittwire">
+
+        <section class="main-content">
+              <div class="region region-content">
+    <div id="block-pitt-pittwire-mainpagecontent" class="block block-system block-system-main-block">
+
+
+      <div class="views-element-container">
+<div class="view view-article-view view-id-article_view view-display-id-pittwire_news js-view-dom-id-4786629703865a9ad95fbd7244ff3765bc630fa9d293395feef7af867f13ea9b">
+            <div class="page-header">
+            <div class="page-header-container">
+                                    <h1 class="page-header-title">Features &amp; Articles
+</h1>
+                            </div>
+        </div>
+                <div class="filter-module">
+            <div class="filter-container">
+                <div class="filter-wrapper">
+                    <h2 class="filter-wrapper-title">Filter By</h2>
+                    <form class="views-exposed-form bef-exposed-form" data-bef-auto-submit-full-form="" data-bef-auto-submit="" data-bef-auto-submit-delay="1000" novalidate="novalidate" data-drupal-selector="views-exposed-form-article-view-pittwire-news" action="/pittwire/news/features-articles" method="get" id="views-exposed-form-article-view-pittwire-news" accept-charset="UTF-8">
+  <div class="filter-grid">
+
+  <fieldset class="js-form-item js-form-type-select form-type-select js-form-item-field-topics-target-id form-item-field-topics-target-id form-group">
+          <label for="edit-field-topics-target-id">Search by topic</label>
+                <select data-drupal-selector="edit-field-topics-target-id" id="edit-field-topics-target-id" name="field_topics_target_id" class="form-select form-control"><option value="All">Topics</option><option value="432" selected="selected">University News</option><option value="2">Health and Wellness</option><option value="391">Technology &amp; Science</option><option value="4">Arts and Humanities</option><option value="6">Community Impact</option><option value="1">Innovation and Research</option><option value="9">Global</option><option value="8">Diversity, Equity, and Inclusion</option><option value="12">Our City/Our Campus</option><option value="7">Teaching &amp; Learning</option><option value="440">Space</option><option value="441">Ukraine</option><option value="470">Sustainability</option></select>
+                  </fieldset>
+
+  <fieldset class="js-form-item js-form-type-select form-type-select js-form-item-field-article-date-value form-item-field-article-date-value form-group">
+          <label for="edit-field-article-date-value">Search by date</label>
+                <select data-drupal-selector="edit-field-article-date-value" id="edit-field-article-date-value" name="field_article_date_value" class="form-select form-control"><option value="" selected="selected">Year</option><option value="2012">2012</option><option value="2015">2015</option><option value="2016">2016</option><option value="2017">2017</option><option value="2018">2018</option><option value="2019">2019</option><option value="2020">2020</option><option value="2021">2021</option><option value="2022">2022</option><option value="2023">2023</option><option value="2024">2024</option></select>
+                  </fieldset>
+
+  <fieldset class="form-title-search js-form-item js-form-type-textfield form-type-textfield js-form-item-title form-item-title form-no-label form-group">
+          <label for="edit-title" class="sr-only">Search News</label>
+                <input placeholder="Search News" data-bef-auto-submit-exclude="" data-drupal-selector="edit-title" type="text" id="edit-title" name="title" value="" size="30" maxlength="128" class="form-text form-control" />
+
+                  </fieldset>
+<input data-drupal-selector="edit-field-category-target-id" type="hidden" name="field_category_target_id" value="All" class="form-control" />
+<div data-drupal-selector="edit-actions" class="form-actions js-form-wrapper form-group" id="edit-actions"><input data-bef-auto-submit-click="" data-drupal-selector="edit-submit-article-view" type="submit" id="edit-submit-article-view" value="Apply" class="button js-form-submit form-submit btn btn-primary form-control" />
+</div>
+
+    <button type="button" class="filter-search-btn"><span class="icon-search"></span> <span class="sr-only">Search News</span></button>
+</div>
+
+</form>
+
+                </div>
+            </div>
+        </div>
+
+            <div class="listing-wrapper">
+            <div class="listing-container">
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/chancellor-gabel-installation">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-04/pittwire-chancellor-installation02-sm-hero-700x570.jpg?h=d8076212&amp;itok=pRweg9B4" alt="Cestello puts a medallion around Gabel&#039;s neck" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/chancellor-gabel-installation">      	  	  Joan Gabel installed as Pitt’s 19th chancellor
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  Gabel praised Pitt’s 237-year legacy and its current momentum and expressed confidence in the institution’s future.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Chancellor
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/2024-us-news-rankings-graduate-schools">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-04/20190628_ao_3006_occupational_therapy_0035_hero.jpg?h=2e6285b4&amp;itok=mAECrF4-" alt="A subject and professor look at brain scans on a monitor" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/2024-us-news-rankings-graduate-schools">      	  	  Pitt’s Occupational Therapy program secures No. 1 spot in 2024 US News and World Report graduate school ranking
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  And, five other programs earned top 10 distinctions on the annual list.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Teaching &amp; Learning
+				</li>
+		      		        <li class="field__item">
+				School of Health and Rehabilitation Sciences
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/shrs-fifth-halket-building-approved-2024">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-04/ext-view-1_strada-sm_hero.jpg?h=de836872&amp;itok=8mDgurJH" alt="A rendering of the future building on Fifth Avenue" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/shrs-fifth-halket-building-approved-2024">      	  	  A new home for Pitt’s School of Health and Rehabilitation Sciences will unite its programs and foster interdisciplinary opportunities
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  The school will occupy six floors in the new building, set for December 2025 completion.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Our City/Our Campus
+				</li>
+		      		        <li class="field__item">
+				School of Health and Rehabilitation Sciences
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/faculty-fulbright-scholars-2024">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-04/20190828_ta_globalhubstock_0045_hero.jpg?h=de836872&amp;itok=GHdDqxVQ" alt="Blue and yellow dots on a world map" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/faculty-fulbright-scholars-2024">      	  	  Meet Pitt’s 2024 faculty Fulbright winners
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  The Fulbright U.S. Scholar Program offers faculty the opportunity to teach and conduct research abroad.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Innovation and Research
+				</li>
+		      		        <li class="field__item">
+				Global
+				</li>
+		      		        <li class="field__item">
+				Faculty
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/goldwater-scholars-2024">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-04/20240313_ao_campus_magnolia_0088_hero.jpg?h=de836872&amp;itok=aRWYU2ha" alt="The Cathedral of Learning behind magnolia blossoms" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/goldwater-scholars-2024">      	  	  Pitt has 2 new Goldwater Scholars
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  The prestigious scholarship is awarded to sophomores and juniors who plan to pursue research careers in the sciences and engineering fields. Meet our winners.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Technology &amp; Science
+				</li>
+		      		        <li class="field__item">
+				David C. Frederick Honors College
+				</li>
+		      		        <li class="field__item">
+				Kenneth P. Dietrich School of Arts and Sciences
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/pittmagazine/features-articles/chancellor-joan-gabel-possibilities">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-04/20230914_ao_gabel_rutenbar_0168-topaz-high-fidelity_gallery.jpg?h=4c6af902&amp;itok=W5OAZyE1" alt="A portrait of Gabel" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/pittmagazine/features-articles/chancellor-joan-gabel-possibilities">      	  	  Pitt Chancellor Joan Gabel is in pursuit of what’s possible
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  Forward-thinking and values-driven, she’s embraced Pitt’s boundless potential throughout her first year as the University’s 19th leader.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/bakken-named-vice-chancellor-secretary-2024">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-03/phil-headshot_700x570px.jpg?h=aa8703e9&amp;itok=_vWlvDI3" alt="Bakken" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/bakken-named-vice-chancellor-secretary-2024">      	  	  Phil Bakken named Pitt’s vice chancellor and secretary of the Board of Trustees
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  He currently serves as the chief of staff to the president and corporation secretary to the Board of Regents of the University of Nebraska System.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Community Impact
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/pitt-madness-bracket-2024-live-updates">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-04/champhero.jpg?h=d8076212&amp;itok=3Xi6dM_6" alt="Roc flexes next to a Top of the Cathedral medallion" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/pitt-madness-bracket-2024-live-updates">      	  	  No. 1 ROC finishes dominant run to win the first Pitt Madness
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  The beloved mascot won each of his rounds with over 59% of the votes. Look back on his matchups throughout the month.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Our City/Our Campus
+				</li>
+		      		        <li class="field__item">
+				Pittsburgh Campus
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/joseph-mccarthy-named-provost-2024">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-03/joe-mccarthy-2023_small.jpg?h=275fddad&amp;itok=7FMYQyPd" alt="McCarthy" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/joseph-mccarthy-named-provost-2024">      	  	  Joseph J. McCarthy named Pitt’s provost and senior vice chancellor
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  He’s served the University for more than 25 years as both an award-winning faculty member and transformative leader.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/pitt-day-of-giving-2024-results">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-02/20240226_ao_pdog_preview_0200_hero_0.jpg?h=a9b6144a&amp;itok=C683nGec" alt="A group of students in blue Pitt Day of Giving shirts smile" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/pitt-day-of-giving-2024-results">      	  	  A record-setting 11,400 alumni and donors raised $2.4 million on Pitt Day of Giving
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  Across the globe, supporters helped fund University scholarships, research, academics, athletics and more.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/general-education-task-force-launch">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-02/20230905_ta_pitt-greensburg_0160_hero.jpg?h=de836872&amp;itok=xfQSfmxR" alt="A professor gestures in front of students sitting in rows of desks" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/general-education-task-force-launch">      	  	  General Education Task Force aims to transform Pitt’s undergraduate experience
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  The three-year project will streamline degree planning, reduce financial burdens and foster interdisciplinary exploration.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Teaching &amp; Learning
+				</li>
+		      		        <li class="field__item">
+				Undergraduate students
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/pitt-chiropractic-program-lower-back-pain">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-02/240106_0026_hero.jpg?h=8843fa1d&amp;itok=rX2H1uAU" alt="Delitto, Schneider and Shekhar in suits" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/pitt-chiropractic-program-lower-back-pain">      	  	  Pitt launches a Doctor of Chiropractic program
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  The evidence-based program will be the first of its kind in Pennsylvania and unique among research-intensive public institutions in the U.S.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Health and Wellness
+				</li>
+		      		        <li class="field__item">
+				School of Health and Rehabilitation Sciences
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/nai-patent-ranking-2024">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-02/20190219_ta_2777_jaradprinkey_0061_hero.jpg?h=de836872&amp;itok=UzflQwSl" alt="A person uses tools on a small metal chip" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/nai-patent-ranking-2024">      	  	  Pitt ranks in top 20 for patents granted to universities worldwide
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  Pitt innovators earned 114 U.S. patents in 2023. Learn how the Innovation Institute can help your invention make it to market.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Innovation and Research
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/pitt-day-of-giving-2024">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-02/20230221_pdog_01_hero.jpg?h=de836872&amp;itok=DU7fZcj7" alt="People hold up puzzle pieces to show a neon light that reads (hashtag) H 2 P" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/pitt-day-of-giving-2024">      	  	  Share your Pitt story and make a gift during PDoG on Feb. 27
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  Gifts help ensure a brighter future for Pitt students for years to come.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/green-achievements-winter-2023">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-02/20240116_ta_winter-campus-stock_0034_hero.jpg?h=de836872&amp;itok=Q6ZLi-RS" alt="A drone shot fades from Pitt&#039;s campus on a snowy day to a sunny day" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/green-achievements-winter-2023">      	  	  Turn your winter from gray to green with these sustainable activities
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  Plus, here’s how Pitt reduced emissions and diverted a record number of donations from landfills.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Sustainability
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/creating-just-community-upside-awards-ceremony-2024">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-01/20230307_ta_reci-conference0076_hero.jpg?h=de836872&amp;itok=ZNuOYx5g" alt="People sit around a table in a room with stained glass windows" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/creating-just-community-upside-awards-ceremony-2024">      	  	  Here’s who won the University’s annual social justice awards
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  The students and staff who make Pitt more just, equitable and inclusive will be recognized during a Jan. 26 luncheon.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Community Impact
+				</li>
+		      		        <li class="field__item">
+				Diversity, Equity, and Inclusion
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/cfo-sastry-steps-down">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-01/20180928_ao_2476_fall_trustees_0015_smallhero.jpg?h=d8076212&amp;itok=gyJAdJvy" alt="Sastry" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/cfo-sastry-steps-down">      	  	  Hari Sastry is stepping down as Pitt’s chief financial officer
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  He’s headed to Georgetown University after a five-year stint at Pitt that included record research funding, increased transparency in the budget process and a focus on diverse supplier initiatives.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Staff
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/pittmagazine/features-articles/alpha-sigma-lambda-50-year-legacy">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2024-01/20231109_ta_asl-alpha-chi_0015_magfull.jpg?h=9cb54f80&amp;itok=y6WLBITR" alt="An older woman stands in front of a photo of her younger self on a screen" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/pittmagazine/features-articles/alpha-sigma-lambda-50-year-legacy">      	  	  This CGS alumna helped bring honor to nontraditional students
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  The 50th anniversary exhibit of honor society recalls outreach to part-time and nontraditional students.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Alumni
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/police-chief-loftus-retires">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2023-12/20230411_jw_5483_pc_smallhero.jpg?h=d8076212&amp;itok=dcxiP_jV" alt="Loftus speaks at a Pitt press conference" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/police-chief-loftus-retires">      	  	  University of Pittsburgh Police Department Chief James Loftus retires
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  Loftus steps down after more than 10 years of service to Pitt. Deputy Chief Holly Lamb will be promoted to chief of police.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Staff
+				</li>
+		      	    </ul>
+
+</div>
+
+
+<div class="news-card image">
+            <figure>
+          <a href="/pittwire/features-articles/winter-commencement-2024-photo-recap">
+                  	  	    <img src="/sites/default/files/styles/pittwire_home_hero/public/2023-12/20231217_ao_winter_commencement_0489_hero.jpg?h=de836872&amp;itok=dywnvAk4" alt="Graduates dance in celebration as confetti falls" loading="lazy" typeof="foaf:Image" class="image-style-pittwire-home-hero" />
+
+
+
+
+          </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/winter-commencement-2024-photo-recap">      	  	  Winter Commencement 2024 in photos
+	        </a></h2>
+          	        <p class="clearfix text-formatted field field--type-text-with-summary field--label-hidden field__item">
+	  	  See the gallery celebrating nearly 700 Pitt graduates who crossed the stage on Dec. 17.
+	  	  </p>
+
+      	    <ul class="news-card-tags field field--type-entity-reference field--label-hidden field__items">
+	      		        <li class="field__item">
+				University News
+				</li>
+		      		        <li class="field__item">
+				Students
+				</li>
+		      		        <li class="field__item">
+				Commencement
+				</li>
+		      	    </ul>
+
+</div>
+
+            </div>
+        </div>
+
+
+  <nav class="pagination" aria-label="Pagination">
+    <h4 id="pagination-heading" class="visually-hidden">Pagination</h4>
+                <a class="pagination-link previous" href="?field_topics_target_id=432&amp;field_article_date_value=&amp;title=&amp;field_category_target_id=All&amp;page=0" data-gtm="" aria-label="Previous"><span class="visually-hidden">Previous page</span></a>
+          <ul class="pagination-list">
+                                <li class="pagination-item">
+                                          <a href="?field_topics_target_id=432&amp;field_article_date_value=&amp;title=&amp;field_category_target_id=All&amp;page=0" title="Go to page 1" class="pagination-link">
+            <span class="visually-hidden">
+              Page
+            </span>1</a>
+        </li>
+              <li class="pagination-item">
+                                          <a href="?field_topics_target_id=432&amp;field_article_date_value=&amp;title=&amp;field_category_target_id=All&amp;page=1" title="Current page" class="pagination-link active">
+            <span class="visually-hidden">
+              Current page
+            </span>2</a>
+        </li>
+              <li class="pagination-item">
+                                          <a href="?field_topics_target_id=432&amp;field_article_date_value=&amp;title=&amp;field_category_target_id=All&amp;page=2" title="Go to page 3" class="pagination-link">
+            <span class="visually-hidden">
+              Page
+            </span>3</a>
+        </li>
+              <li class="pagination-item">
+                                          <a href="?field_topics_target_id=432&amp;field_article_date_value=&amp;title=&amp;field_category_target_id=All&amp;page=3" title="Go to page 4" class="pagination-link">
+            <span class="visually-hidden">
+              Page
+            </span>4</a>
+        </li>
+              <li class="pagination-item">
+                                          <a href="?field_topics_target_id=432&amp;field_article_date_value=&amp;title=&amp;field_category_target_id=All&amp;page=4" title="Go to page 5" class="pagination-link">
+            <span class="visually-hidden">
+              Page
+            </span>5</a>
+        </li>
+              <li class="pagination-item">
+                                          <a href="?field_topics_target_id=432&amp;field_article_date_value=&amp;title=&amp;field_category_target_id=All&amp;page=5" title="Go to page 6" class="pagination-link">
+            <span class="visually-hidden">
+              Page
+            </span>6</a>
+        </li>
+              <li class="pagination-item">
+                                          <a href="?field_topics_target_id=432&amp;field_article_date_value=&amp;title=&amp;field_category_target_id=All&amp;page=6" title="Go to page 7" class="pagination-link">
+            <span class="visually-hidden">
+              Page
+            </span>7</a>
+        </li>
+              <li class="pagination-item">
+                                          <a href="?field_topics_target_id=432&amp;field_article_date_value=&amp;title=&amp;field_category_target_id=All&amp;page=7" title="Go to page 8" class="pagination-link">
+            <span class="visually-hidden">
+              Page
+            </span>8</a>
+        </li>
+              <li class="pagination-item">
+                                          <a href="?field_topics_target_id=432&amp;field_article_date_value=&amp;title=&amp;field_category_target_id=All&amp;page=8" title="Go to page 9" class="pagination-link">
+            <span class="visually-hidden">
+              Page
+            </span>9</a>
+        </li>
+              <li class="pagination-item">
+                                          <a href="?field_topics_target_id=432&amp;field_article_date_value=&amp;title=&amp;field_category_target_id=All&amp;page=9" title="Go to page 10" class="pagination-link">
+            <span class="visually-hidden">
+              Page
+            </span>10</a>
+        </li>
+                            <li class="pagination-item">...</li>
+                </ul>
+                <a class="pagination-link next" href="?field_topics_target_id=432&amp;field_article_date_value=&amp;title=&amp;field_category_target_id=All&amp;page=2" data-gtm="" aria-label="Next"><span class="visually-hidden">Next page</span></a>
+        </nav>
+
+                    </div>
+</div>
+
+  </div>
+
+  </div>
+
+        </section>
+
+        <div class="right-rail">
+            <div class="right-rail-content">
+                  <div class="region region-right-sidebar">
+    <div id="block-manualfeaturedcards" class="block block-fixed-block-content block-fixed-block-contentmanual-featured-cards">
+
+
+
+
+<div class="news-card video">
+            <figure>
+            <a href="/pittwire/features-articles/gabel-council-competitiveness-education">
+                      	  	    <img src="/sites/default/files/styles/news_card_sidebar/public/2023-11/20220223_ao_machine_shop_0183_hero.jpg?h=b273ae4c&amp;itok=5WHtZ_O5" alt="People gather around a machine that makes quantum computing parts" loading="lazy" typeof="foaf:Image" class="image-style-news-card-sidebar" />
+
+
+
+
+            </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/gabel-council-competitiveness-education">      	  	  Chancellor Gabel highlights higher education’s role in keeping America competitive
+	        </a></h2>
+</div>
+
+
+
+<div class="news-card image">
+            <figure>
+            <a href="/pittwire/features-articles/shadow-bandits-eclipse-chasing">
+                      	  	    <img src="/sites/default/files/styles/news_card_sidebar/public/2023-10/20230909_ta_shadow-bandits_allegheny-observatory_0115_hero.jpg?h=77bf0f74&amp;itok=SMFN0NJ7" alt="One student fills a large weather balloon with air while another holds it above her head" loading="lazy" typeof="foaf:Image" class="image-style-news-card-sidebar" />
+
+
+
+
+            </a>
+        </figure>
+        <h2 class="news-card-title"><a href="/pittwire/features-articles/shadow-bandits-eclipse-chasing">      	  	  These Pitt students are following the eclipse to Texas
+	        </a></h2>
+</div>
+
+
+
+
+  </div>
+
+    <div class="pittwire-heading">Trending</div>
+    <div><div class="view view-trending-articles view-id-trending_articles view-display-id-trending js-view-dom-id-184a372b9d5d3903504eb62973ae3928b9a462c42460c963885590c4675b0738">
+
+
+
+      <div class="view-content">
+          <div class="news-card views-row"><div class="views-field views-field-title"><span class="field-content"><h2 class="news-card-title"><a href="/pittwire/announcements-and-updates/new-winter-commencement-date-2024">Pitt’s winter commencement is now on Dec. 18</a></h2>
+</span></div></div>
+    <div class="news-card views-row"><div class="views-field views-field-title"><span class="field-content"><h2 class="news-card-title"><a href="/pittwire/announcements-and-updates/community-engaged-scholarship-project-development-cohort-2024">Apply for a program on developing community engaged scholarship projects</a></h2>
+</span></div></div>
+    <div class="news-card views-row"><div class="views-field views-field-title"><span class="field-content"><h2 class="news-card-title"><a href="/pittwire/accolades-honors/bradford-college-distinction-10-years">Pitt-Bradford has been a College of Distinction for a decade</a></h2>
+</span></div></div>
+
+    </div>
+
+          </div>
+</div>
+
+<!-- Subscribe Module -->
+<div id="block-subscribetopittwire" class="subscribe-wrapper block block-fixed-block-content block-fixed-block-contentsubscribe-to-pittwire">
+    <div class="subscribe-inner">
+          	        <figure class="field field--type-entity-reference field--label-hidden field__item">
+	  	    <img src="/sites/default/files/styles/subscription_callout/public/2021-07/img-pittwire-subscribe.png?h=7f3918f9&amp;itok=hC3ZYfSz" alt="FPO Tower" loading="lazy" typeof="foaf:Image" class="image-style-subscription-callout" />
+
+
+
+	  	  </figure>
+
+    <div class="subscribe-content">
+            	        <h2 class="subscribe-content-title field field--type-string field--label-hidden field__item">
+	  	  Subscribe to Pittwire Today
+	  	  </h2>
+
+            	  	  Get the most interesting and important stories from the University of Pittsburgh.
+
+    </div>
+  </div>
+  <div class="subscribe-form">
+    <div class="subscribe-form-btn">
+      <a href="/subscribe-pittwire" class="btn-submit">      	  	  Subscribe
+	        </a>
+    </div>
+  </div>
+  </div>
+
+  </div>
+
+            </div>
+        </div>
+    </div>
+
+</main>
+
+  <footer class="footer">
+                	        <div class="footer-bg field field--type-entity-reference field--label-hidden field__item">
+	  	    <img src="/sites/default/files/styles/footer_background/public/2021-03/img-bridge.png?itok=YCj_wGW3" alt="Bridge Icon" loading="lazy" typeof="foaf:Image" class="image-style-footer-background" />
+
+
+
+	  	  </div>
+
+  <div id="block-pitt-pittwire-footerblocks" class="footer-container">
+      <!-- Logo and Links -->
+<div class="footer-navigation" data-max-columns="2">
+      <div id="block-pitt-pittwire-sitebranding-2" class="footer-navigation-logo block block-system block-system-branding-block">
+
+
+        <a href="/" title="University of Pittsburgh" rel="home" class="site-logo">
+      <img src="/themes/custom/pitt_pittwire/logo.svg" alt="University of Pittsburgh" />
+    </a>
+    </div>
+<nav role="navigation" aria-labelledby="block-globalmenu-2-menu" id="block-globalmenu-2" class="menu--footer block block-menu navigation menu--global-menu">
+
+  <h2 class="visually-hidden" id="block-globalmenu-2-menu">Global Menu</h2>
+
+
+
+        <ul>
+          <li>
+        <a href="https://admissions.pitt.edu/apply/">Apply</a>
+      </li>
+          <li>
+        <a href="https://admissions.pitt.edu/visit/unscripted/">Visit</a>
+      </li>
+          <li>
+        <a href="https://www.giveto.pitt.edu/s/1729/18/home-giving.aspx?gid=2&amp;pgid=2135">Give</a>
+      </li>
+          <li>
+        <a href="/pittwire" data-drupal-link-system-path="node/18">Pittwire</a>
+      </li>
+          <li>
+        <a href="http://calendar.pitt.edu/">Events</a>
+      </li>
+        </ul>
+
+
+
+  </nav>
+
+  </div>
+<div class="footer-main" data-max-columns="2">
+      <!-- Footer Main Menu -->
+<div class="footer-sitemap" data-max-columns="2">
+
+                    <ul>
+              <li>
+		<a href="/about" class="data-gtm-footerLinksCategory">About</a>
+        </li>
+                        <li>
+		<a href="/academics" class="data-gtm-footerLinksCategory">Academics</a>
+        </li>
+                        <li>
+		<a href="/admissions" class="data-gtm-footerLinksCategory">Admissions</a>
+        </li>
+            </ul>
+                      <ul>
+              <li>
+		<a href="/research" class="data-gtm-footerLinksCategory">Research</a>
+        </li>
+                        <li>
+		<a href="/student-life" class="data-gtm-footerLinksCategory">Life at Pitt</a>
+        </li>
+                        <li>
+		<a href="http://pittsburghpanthers.com/" class="data-gtm-footerLinksCategory">Athletics</a>
+        </li>
+            </ul>
+
+
+<!-- End Main Menu -->
+
+  </div>
+<div id="block-footerquicklinksandcontact-2" class="block block-blockgroup block-block-groupfooter-quick-links-and-contact">
+
+
+      <!-- Quick Links and Contact Info -->
+<div class="footer-quicklinks">
+  <!-- Quick Links -->
+  <div class="collapse--secondary" data-max-columns="2">
+      <div id="block-pitt-pittwire-footerquicklinkscolumn1" class="block block-blockgroup block-block-groupfooter-quick-links-column-1">
+
+
+      <!-- collapse item -->
+<div class="footer-quicklinks-item">
+  <button id="quick-links-resources" class="collapse-trigger--md collapsed footer-quicklinks-item-header" role="tab" data-toggle="collapse" data-target="#collapse-item-quick-links-resources" aria-expanded="false" aria-controls="collapse-item-quick-links-resources" data-gtm="">Quick Links &amp; Resources</button>
+  <div id="collapse-item-quick-links-resources" class="collapse-target--md collapse" role="tabpanel" aria-labelledby="quick-links-resources">
+    <div class="collapse-content">
+      <div class="footer-quicklinks-item-header">Quick Links &amp; Resources</div>
+
+        <ul>
+            <li>
+		<a href="https://www.diversity.pitt.edu/accessibility-statement" class="data-gtm-footerLinksKPI">Accessibility Statement</a>
+        </li>
+            <li>
+		<a href="https://www.affordability.pitt.edu/" class="data-gtm-footerLinksKPI">Affordability</a>
+        </li>
+            <li>
+		<a href="https://www.join.pitt.edu/" class="data-gtm-footerLinksKPI">Careers</a>
+        </li>
+            <li>
+		<a href="/about/general-info" class="data-gtm-footerLinksKPI">Consumer Info/Achievement</a>
+        </li>
+            <li>
+		<a href="/contact" class="data-gtm-footerLinksKPI">Contact Us</a>
+        </li>
+            <li>
+		<a href="https://www.academics.pitt.edu/programs/a-z" class="data-gtm-footerLinksKPI">Departments A-Z</a>
+        </li>
+            <li>
+		<a href="https://www.diversity.pitt.edu/" class="data-gtm-footerLinksKPI">Diversity, Equity and Inclusion</a>
+        </li>
+            <li>
+		<a href="https://find.pitt.edu/" class="data-gtm-footerLinksKPI">Find People</a>
+        </li>
+            <li>
+		<a href="https://www.technology.pitt.edu/" class="data-gtm-footerLinksKPI">Information Technology</a>
+        </li>
+            <li>
+		<a href="https://www.lgbtq.pitt.edu/" class="data-gtm-footerLinksKPI">LGBTQ+</a>
+        </li>
+            <li>
+		<a href="https://www.diversity.pitt.edu/notice-nondiscrimination-and-anti-harassment-policy-statement" class="data-gtm-footerLinksKPI">Nondiscrimination and Anti-Harassment Policy</a>
+        </li>
+            <li>
+		<a href="https://www.pitt.edu/privacy-policy" class="data-gtm-footerLinksKPI">Privacy Policy</a>
+        </li>
+            <li>
+		<a href="https://www.pitt.edu/accountability" class="data-gtm-footerLinksKPI">Promoting Accountability and Trust</a>
+        </li>
+            <li>
+		<a href="http://my.pitt.edu" class="data-gtm-footerLinksKPI">My Pitt</a>
+        </li>
+        </ul>
+
+
+
+          </div>
+  </div>
+</div>
+<!-- collapse item -->
+<div class="footer-quicklinks-item">
+  <button id="regional-campuses" class="collapse-trigger--md collapsed footer-quicklinks-item-header" role="tab" data-toggle="collapse" data-target="#collapse-item-regional-campuses" aria-expanded="false" aria-controls="collapse-item-regional-campuses" data-gtm="">Regional Campuses</button>
+  <div id="collapse-item-regional-campuses" class="collapse-target--md collapse" role="tabpanel" aria-labelledby="regional-campuses">
+    <div class="collapse-content">
+      <div class="footer-quicklinks-item-header">Regional Campuses</div>
+
+        <ul>
+            <li>
+		<a href="https://upb.pitt.edu/" class="data-gtm-footerLinksKPI">Bradford</a>
+        </li>
+            <li>
+		<a href="http://www.greensburg.pitt.edu/" class="data-gtm-footerLinksKPI">Greensburg</a>
+        </li>
+            <li>
+		<a href="https://www.johnstown.pitt.edu/" class="data-gtm-footerLinksKPI">Johnstown</a>
+        </li>
+            <li>
+		<a href="https://www.titusville.pitt.edu/" class="data-gtm-footerLinksKPI">Titusville</a>
+        </li>
+        </ul>
+
+
+
+          </div>
+  </div>
+</div>
+
+  </div>
+<div id="block-pitt-pittwire-footerquicklinkscolumn2" class="block block-blockgroup block-block-groupfooter-quick-links-column-2">
+
+
+      <!-- collapse item -->
+<div class="footer-quicklinks-item">
+  <button id="colleges-schools" class="collapse-trigger--md collapsed footer-quicklinks-item-header" role="tab" data-toggle="collapse" data-target="#collapse-item-colleges-schools" aria-expanded="false" aria-controls="collapse-item-colleges-schools" data-gtm="">Colleges &amp; Schools</button>
+  <div id="collapse-item-colleges-schools" class="collapse-target--md collapse" role="tabpanel" aria-labelledby="colleges-schools">
+    <div class="collapse-content">
+      <div class="footer-quicklinks-item-header">Colleges &amp; Schools</div>
+
+        <ul>
+            <li>
+		<a href="https://www.as.pitt.edu" class="data-gtm-footerLinksKPI">Arts &amp; Sciences</a>
+        </li>
+            <li>
+		<a href="https://www.business.pitt.edu" class="data-gtm-footerLinksKPI">Business</a>
+        </li>
+            <li>
+		<a href="https://www.sci.pitt.edu" class="data-gtm-footerLinksKPI">Computing &amp; Information</a>
+        </li>
+            <li>
+		<a href="https://www.dental.pitt.edu" class="data-gtm-footerLinksKPI">Dental Medicine</a>
+        </li>
+            <li>
+		<a href="https://www.education.pitt.edu" class="data-gtm-footerLinksKPI">Education</a>
+        </li>
+            <li>
+		<a href="https://www.engineering.pitt.edu" class="data-gtm-footerLinksKPI">Engineering</a>
+        </li>
+            <li>
+		<a href="https://www.cgs.pitt.edu" class="data-gtm-footerLinksKPI">General Studies</a>
+        </li>
+            <li>
+		<a href="https://www.shrs.pitt.edu" class="data-gtm-footerLinksKPI">Health &amp; Rehabilitation</a>
+        </li>
+            <li>
+		<a href="https://www.honors.pitt.edu" class="data-gtm-footerLinksKPI">Honors College</a>
+        </li>
+            <li>
+		<a href="https://www.law.pitt.edu" class="data-gtm-footerLinksKPI">Law</a>
+        </li>
+            <li>
+		<a href="https://www.medschool.pitt.edu" class="data-gtm-footerLinksKPI">Medicine</a>
+        </li>
+            <li>
+		<a href="https://www.nursing.pitt.edu" class="data-gtm-footerLinksKPI">Nursing</a>
+        </li>
+            <li>
+		<a href="https://www.pharmacy.pitt.edu" class="data-gtm-footerLinksKPI">Pharmacy</a>
+        </li>
+            <li>
+		<a href="https://www.gspia.pitt.edu" class="data-gtm-footerLinksKPI">Public &amp; Intl Affairs</a>
+        </li>
+            <li>
+		<a href="https://publichealth.pitt.edu/" class="data-gtm-footerLinksKPI">Public Health</a>
+        </li>
+            <li>
+		<a href="https://www.socialwork.pitt.edu/" class="data-gtm-footerLinksKPI">Social Work</a>
+        </li>
+        </ul>
+
+
+
+          </div>
+  </div>
+</div>
+
+  </div>
+
+    </div>
+</div>
+<div id="block-footercontact-2" class="footer-contact block block-blockgroup block-block-groupfooter-contact">
+
+
+      <div id="block-footersiteinformation-2" class="block block-block-content block-block-content60643064-ee6c-4394-90c4-9e061373c0d4">
+
+
+            	        <div class="field field--type-address field--label-hidden field__item">
+	  	  <p class="address" translate="no"><span class="address-line1">4200 Fifth Ave.</span><br>
+<span class="locality">Pittsburgh</span>, <span class="administrative-area">PA</span> <span class="postal-code">15260</span><br>
+<span class="country">United States</span></p>
+	  	  </div>
+	              	        <div class="field field--type-telephone field--label-hidden field__item">
+	  	  <a href="tel:+1-412-624-4141">+1 412-624-4141</a>
+	  	  </div>
+
+  </div>
+<div id="block-socialmedialinks-2" class="block-social-media-links block block-social-media-links-block">
+
+
+
+
+<ul class="social-media-links--platforms platforms inline horizontal">
+      <li>
+      <a class="social-media-link-icon--twitter" href="https://www.twitter.com/PittTweet"  target="_blank" >
+          <i class="micon fa-twitter" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Twitter</span>
+      </a>
+    </li>
+      <li>
+      <a class="social-media-link-icon--instagram" href="https://www.instagram.com/pittofficial"  target="_blank" >
+          <i class="micon fa-instagram" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Instagram</span>
+      </a>
+    </li>
+      <li>
+      <a class="social-media-link-icon--facebook" href="https://www.facebook.com/upitt"  target="_blank" >
+          <i class="micon fa-facebook" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Facebook</span>
+      </a>
+    </li>
+      <li>
+      <a class="social-media-link-icon--youtube" href="https://www.youtube.com/user/pittweb"  target="_blank" >
+          <i class="micon fa-youtube" aria-hidden="true"></i>
+
+
+                <span class="platform--name visually-hidden">Youtube</span>
+      </a>
+    </li>
+  </ul>
+
+  </div>
+
+  </div>
+
+  </div>
+
+  </div>
+
+  </div>
+
+  </footer>
+
+
+
+
+
+  </div>
+
+
+    <script type="application/json" data-drupal-selector="drupal-settings-json">{"path":{"baseUrl":"\/","scriptPath":null,"pathPrefix":"","currentPath":"pittwire\/news\/features-\u0026-articles","currentPathIsAdmin":false,"isFront":false,"currentLanguage":"en","currentQuery":{"field_article_date_value":"","field_category_target_id":"All","field_topics_target_id":"432","page":"1","title":""}},"pluralDelimiter":"\u0003","suppressDeprecationErrors":true,"ajaxPageState":{"libraries":"better_exposed_filters\/auto_submit,better_exposed_filters\/general,choices\/choices,core\/drupal.ajax,entity_overlay\/entity_overlay.behaviors,extlink\/drupal.extlink,media\/oembed.formatter,micon\/micon,paragraphs\/drupal.paragraphs.unpublished,pitt_default\/card,pitt_default\/choices,pitt_default\/global-styling,pitt_default\/media-item,pitt_default\/modal,pitt_default\/pagination,social_media_links\/social_media_links.theme,system\/base,views\/views.module,zenny\/base,zensource_front_end\/classy.messages,zensource_front_end\/global-styling","theme":"pitt_pittwire","theme_token":"zjXQDBdTMt2mZC4y4bJWrE4DGi6Fcf67Lf6JMhH4rBU"},"ajaxTrustedUrl":{"\/pittwire\/news\/features-articles":true},"data":{"extlink":{"extTarget":false,"extTargetNoOverride":false,"extNofollow":false,"extNoreferrer":true,"extFollowNoOverride":false,"extClass":"0","extLabel":"(link is external)","extImgClass":false,"extSubdomains":true,"extExclude":"","extInclude":"","extCssExclude":"#block-socialmedialinks","extCssExplicit":"","extAlert":false,"extAlertText":"This link will take you to an external web site. We are not responsible for their content.","mailtoClass":"0","mailtoLabel":"(link sends email)","extUseFontAwesome":false,"extIconPlacement":"append","extFaLinkClasses":"fa fa-external-link","extFaMailtoClasses":"fa fa-envelope-o","whitelistedDomains":[]}},"entity_overlay":{"media_8412":{"overlay_url":"\/entity_overlay\/load\/nojs\/media\/8412\/modal","path_match":["media\/8412","\/media\/8412"],"dialog_type":"core_modal"}},"choices":{"cssSelector":["select[multiple=multiple]\r","select#edit-field-topics-target-id\r","select#edit-field-article-date-value\r","select#edit-field-pittwire-home-hero\r","select[id*=\u0022-subform-field-featured-article\u0022]"]},"user":{"uid":0,"permissionsHash":"45709791c536f1a56041d94d00891fba6b9156605a804ed14b7a260a9fb3cf47"}}</script>
+<script src="/themes/custom/pitt_default/js/gsap/dist/gsap.min.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/gsap/dist/ScrollTrigger.min.js?v=9.3.21"></script>
+<script src="/core/assets/vendor/jquery/jquery.min.js?v=3.6.0"></script>
+<script src="/core/misc/polyfills/element.matches.js?v=9.3.21"></script>
+<script src="/core/misc/polyfills/object.assign.js?v=9.3.21"></script>
+<script src="/core/assets/vendor/css-escape/css.escape.js?v=1.5.1"></script>
+<script src="/core/assets/vendor/once/once.min.js?v=1.0.1"></script>
+<script src="/core/assets/vendor/jquery-once/jquery.once.min.js?v=2.2.3"></script>
+<script src="/core/misc/drupalSettingsLoader.js?v=9.3.21"></script>
+<script src="/core/misc/drupal.js?v=9.3.21"></script>
+<script src="/core/misc/drupal.init.js?v=9.3.21"></script>
+<script src="/core/assets/vendor/tabbable/index.umd.min.js?v=5.2.1"></script>
+<script src="/core/misc/debounce.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/collapse-native.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/collapse.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/transition.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/hoverintent.min.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/navigation.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/userInterface.js?v=9.3.21"></script>
+<script src="/themes/contrib/zensource_front_end/js/global.js?v=9.3.21"></script>
+<script src="/core/misc/jquery.once.bc.js?v=9.3.21"></script>
+<script src="/modules/contrib/extlink/extlink.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/card.js?shklz9"></script>
+<script src="/modules/contrib/entity_overlay/js/behaviors.js?v=9.3.21"></script>
+<script src="/core/misc/progress.js?v=9.3.21"></script>
+<script src="/core/modules/responsive_image/js/responsive_image.ajax.js?v=9.3.21"></script>
+<script src="/core/misc/ajax.js?v=9.3.21"></script>
+<script src="/themes/custom/pitt_default/js/media-item.js?shklz9"></script>
+<script src="/modules/contrib/better_exposed_filters/js/better_exposed_filters.js?v=4.x"></script>
+<script src="/modules/contrib/better_exposed_filters/js/auto_submit.js?v=4.x"></script>
+<script src="/libraries/choices.js/public/assets/scripts/choices.min.js?shklz9"></script>
+<script src="/themes/contrib/zenny/js/choices.js?shklz9"></script>
+<script src="/themes/custom/pitt_default/js/filter-search.js?shklz9"></script>
+<script src="/themes/custom/pitt_default/js/modal-native.js?shklz9"></script>
+<script src="/themes/custom/pitt_default/js/modal.js?shklz9"></script>
+
+  <script type="text/javascript">window.NREUM||(NREUM={});NREUM.info={"beacon":"bam.nr-data.net","licenseKey":"NRJS-32db2f37a7e1f41235a","applicationID":"1009016335","transactionName":"NAAAYUNYCBFXVEddVw1KI1ZFUAkMGXNBQUgCCT5DWFwREWplXEFMCgsFaWdQAxVmVlRRewwLFkdeVQoHRBoNXFkNAQ5Q","queueTime":0,"applicationTime":795,"atts":"GEcDFwtCGx8=","errorBeacon":"bam.nr-data.net","agent":""}</script></body>
+</html>


### PR DESCRIPTION
Fixes #128, fixes #166

Rewrite the `news` module because the underlying news API has been dead for years. The rewritten `news.py` scrapes the Pittwire website for official Pitt news articles. The rewritten unit tests for `news.py` mocks API requests and achieves 100% code coverage with `pytest`.