### PR TITLE
Get up to 100% test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,4 +9,5 @@ omit =
     /Library/Frameworks/*
 
 [report]
+fail_under = 100
 show_missing = True

--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -30,4 +30,4 @@ jobs:
       - name: Format with black
         run: uv run black --line-length=127 --check --diff .
       - name: Run all tests with pytest
-        run: uv run pytest --cov=pittapi tests/
+        run: uv run pytest --cov=pittapi --cov-branch --cov-fail-under=100 tests/

--- a/pittapi/cal.py
+++ b/pittapi/cal.py
@@ -26,7 +26,7 @@ class Event(NamedTuple):
     date: str
     title: str
     content: str
-    meta: str
+    meta: list[str]
 
 
 ACADEMIC_CALENDAR_URL: str = "https://25livepub.collegenet.com/calendars/pitt-academic-calendar.json"

--- a/pittapi/shuttle.py
+++ b/pittapi/shuttle.py
@@ -20,7 +20,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 import requests
 from typing import Any
 
-
 JSON = dict[str, Any]
 
 API_KEY = "8882812681"

--- a/pittapi/sports.py
+++ b/pittapi/sports.py
@@ -62,11 +62,11 @@ def get_next_mens_basketball_game() -> GameInfo:
             status = "GAME_COMPLETE"
         elif next_game["competitions"][0]["status"]["type"]["name"] == "STATUS_IN_PROGRESS":
             status = "IN_PROGRESS"
-        if next_game["competitions"][0]["competitors"][0]["id"] == 221:
-            opponent = next_game["competitions"][0]["competitors"][0]
+        if str(next_game["competitions"][0]["competitors"][0]["id"]) == "221":
+            opponent = next_game["competitions"][0]["competitors"][1]
             homeaway = next_game["competitions"][0]["competitors"][0]["homeAway"]
         else:
-            opponent = next_game["competitions"][0]["competitors"][1]
+            opponent = next_game["competitions"][0]["competitors"][0]
             homeaway = next_game["competitions"][0]["competitors"][1]["homeAway"]
         return GameInfo(
             timestamp=next_game["date"],
@@ -118,7 +118,7 @@ def get_next_football_game() -> GameInfo:
             status = "GAME_COMPLETE"
         elif next_game["competitions"][0]["status"]["type"]["name"] == "STATUS_IN_PROGRESS":
             status = "IN_PROGRESS"
-        if next_game["competitions"][0]["competitors"][0]["id"] == 221:
+        if str(next_game["competitions"][0]["competitors"][0]["id"]) == "221":
             opponent = next_game["competitions"][0]["competitors"][1]
             homeaway = next_game["competitions"][0]["competitors"][0]["homeAway"]
         else:

--- a/tests/cal_test.py
+++ b/tests/cal_test.py
@@ -1,0 +1,40 @@
+import unittest
+
+import responses
+
+from pittapi import cal
+
+
+class CalendarTest(unittest.TestCase):
+    @responses.activate
+    def test_calendar_endpoints(self):
+        event_data = [
+            {
+                "title": "Fall term begins",
+                "startDateTime": "2026-08-24T00:00:00",
+                "customFields": [{"label": "Event Title", "value": "First day of classes"}],
+                "categoryCalendar": "Academic|Fall",
+            }
+        ]
+        calendar_functions = {
+            cal.ACADEMIC_CALENDAR_URL: cal.get_academic_calendar,
+            cal.GRADES_CALENDAR_URL: cal.get_grades_calendar,
+            cal.ENROLLMENT_CALENDAR_URL: cal.get_enrollment_calendar,
+            cal.COURSE_CALENDAR_URL: cal.get_course_calendar,
+            cal.GRADUATION_CALENDAR_URL: cal.get_graduation_calendar,
+        }
+
+        for url, calendar_function in calendar_functions.items():
+            with self.subTest(url=url):
+                responses.add(responses.GET, url, json=event_data, status=200)
+                self.assertEqual(
+                    calendar_function(),
+                    [
+                        cal.Event(
+                            date="2026-08-24",
+                            title="Fall term begins",
+                            content="First day of classes",
+                            meta=["Academic", "Fall"],
+                        )
+                    ],
+                )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import socket
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def block_live_network(monkeypatch):
+    def fail_on_network(*args, **kwargs):
+        raise AssertionError("Tests must mock all network access")
+
+    monkeypatch.setattr(socket, "create_connection", fail_on_network)
+    monkeypatch.setattr(socket.socket, "connect", fail_on_network)

--- a/tests/course_test.py
+++ b/tests/course_test.py
@@ -17,9 +17,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 
+from copy import deepcopy
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import patch
 
+import responses
 from pittapi import course
 
 from pittapi.course import Attribute, Course, CourseDetails, Instructor, Meeting, Section, SectionDetails, Subject
@@ -36,8 +38,12 @@ from tests.mocks.course_mocks import (
 
 class CourseTest(unittest.TestCase):
     def setUp(self):
-        course._get_subjects = MagicMock(return_value=mocked_subject_data)
-        course._get_section_details = MagicMock(return_value=mocked_section_details_data)
+        subjects_patcher = patch.object(course, "_get_subjects", return_value=mocked_subject_data)
+        section_details_patcher = patch.object(course, "_get_section_details", return_value=mocked_section_details_data)
+        self.mock_get_subjects = subjects_patcher.start()
+        self.mock_get_section_details = section_details_patcher.start()
+        self.addCleanup(subjects_patcher.stop)
+        self.addCleanup(section_details_patcher.stop)
 
     def test_validate_term(self):
         # If convert to string
@@ -73,12 +79,10 @@ class CourseTest(unittest.TestCase):
         self.assertRaises(ValueError, course._validate_course, "10000")
 
     def test_get_subject_courses(self):
-        course._get_subject_courses = MagicMock(return_value=mocked_courses_data)
+        with patch.object(course, "_get_subject_courses", return_value=mocked_courses_data) as get_subject_courses:
+            subject_courses = course.get_subject_courses("CS")
 
-        subject_courses = course.get_subject_courses("CS")
-
-        course._get_subject_courses.assert_called_once_with("CS")
-
+        get_subject_courses.assert_called_once_with("CS")
         self.assertTrue(isinstance(subject_courses, Subject))
 
         self.assertEqual(len(subject_courses.courses), 1)
@@ -87,17 +91,18 @@ class CourseTest(unittest.TestCase):
         self.assertTrue(isinstance(test_course, Course))
 
     def test_get_subject_courses_invalid(self):
-        course._get_subject_courses = MagicMock(return_value=mocked_courses_data_invalid)
+        with patch.object(course, "_get_subject_courses", return_value=mocked_courses_data_invalid) as get_subject_courses:
+            self.assertRaises(ValueError, course.get_subject_courses, "nonsense")
 
-        self.assertRaises(ValueError, course.get_subject_courses, "nonsense")
-        course._get_subject_courses.assert_not_called()
+        get_subject_courses.assert_not_called()
 
     def test_get_course_details(self):
-        course._get_course_id = MagicMock(return_value="105611")
-        course._get_course_info = MagicMock(return_value=mocked_course_info_data)
-        course._get_course_sections = MagicMock(return_value=mocked_course_sections_data)
-
-        course_sections = course.get_course_details("2231", "CS", "0007")
+        with (
+            patch.object(course, "_get_course_id", return_value="105611"),
+            patch.object(course, "_get_course_info", return_value=mocked_course_info_data),
+            patch.object(course, "_get_course_sections", return_value=mocked_course_sections_data),
+        ):
+            course_sections = course.get_course_details("2231", "CS", "0007")
 
         self.assertTrue(isinstance(course_sections, CourseDetails))
 
@@ -143,8 +148,6 @@ class CourseTest(unittest.TestCase):
         self.assertEqual(test_instructor.name, "Robert Fishel")
 
     def test_get_section_details(self):
-        course._get_section_details = MagicMock(return_value=mocked_section_details_data)
-
         section_details = course.get_section_details("2231", "27815")
 
         self.assertTrue(isinstance(section_details, Section))
@@ -178,3 +181,123 @@ class CourseTest(unittest.TestCase):
         self.assertEqual(test_details.wait_list_total, "7")
         self.assertEqual(test_details.valid_to_enroll, "T")
         self.assertIsNone(test_details.combined_section_numbers)
+
+    def test_get_course_details_without_optional_data(self):
+        course_info = deepcopy(mocked_course_info_data)
+        course_info["course_details"].pop("offerings")
+        course_info["course_details"]["components"] = []
+        course_info["course_details"]["attributes"] = []
+        course_sections = deepcopy(mocked_course_sections_data)
+        course_sections["sections"][0]["instructors"] = []
+        course_sections["sections"][0]["meetings"] = []
+
+        with (
+            patch.object(course, "_get_course_id", return_value="105611"),
+            patch.object(course, "_get_course_info", return_value=course_info),
+            patch.object(course, "_get_course_sections", return_value=course_sections),
+        ):
+            details = course.get_course_details("2231", "CS", "0007")
+
+        self.assertIsNone(details.requisites)
+        self.assertIsNone(details.components)
+        self.assertIsNone(details.attributes)
+        self.assertIsNone(details.sections[0].instructors)
+        self.assertIsNone(details.sections[0].meetings)
+
+    def test_get_section_details_without_meetings_and_with_combined_sections(self):
+        section_data = deepcopy(mocked_section_details_data)
+        section_data["section_info"]["meetings"] = []
+        section_data["section_info"]["is_combined"] = True
+        section_data["section_info"]["combined_sections"] = [{"class_nbr": "27815"}, {"class_nbr": "27816"}]
+
+        with patch.object(course, "_get_section_details", return_value=section_data):
+            section = course.get_section_details("2231", "27815")
+
+        self.assertIsNone(section.meetings)
+        self.assertEqual(section.details.combined_section_numbers, ["27815", "27816"])
+
+    def test_get_section_details_without_meeting_instructors(self):
+        section_data = deepcopy(mocked_section_details_data)
+        section_data["section_info"]["meetings"][0]["instructors"] = []
+
+        with patch.object(course, "_get_section_details", return_value=section_data):
+            section = course.get_section_details("2231", "27815")
+
+        self.assertIsNone(section.meetings[0].instructors)
+
+    def test_internal_course_id_helpers(self):
+        duplicate_courses = {
+            "courses": [
+                {"catalog_nbr": "0007", "crse_id": "first"},
+                {"catalog_nbr": "0007", "crse_id": "duplicate"},
+            ]
+        }
+        with patch.object(course, "_get_subject_courses", return_value=duplicate_courses):
+            self.assertEqual(course._get_internal_id_dict("CS"), {"0007": "first"})
+            self.assertEqual(course._get_course_id("CS", "0007"), "first")
+            with self.assertRaisesRegex(ValueError, "No course with that number"):
+                course._get_course_id("CS", "9999")
+
+
+class CourseHttpHelperTest(unittest.TestCase):
+    @responses.activate
+    def test_subject_and_course_http_helpers(self):
+        responses.add(responses.GET, course.SUBJECTS_API, json=mocked_subject_data, status=200)
+        responses.add(
+            responses.GET,
+            course.SUBJECT_COURSES_API.format(subject="CS"),
+            json=mocked_courses_data,
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            course.COURSE_DETAIL_API.format(id="105611"),
+            json=mocked_course_info_data,
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            course.COURSE_SECTIONS_API.format(id="105611", term="2231"),
+            json=mocked_course_sections_data,
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            course.SECTION_DETAILS_API.format(term="2231", id="27815"),
+            json=mocked_section_details_data,
+            status=200,
+        )
+
+        self.assertEqual(course._get_subjects(), mocked_subject_data)
+        self.assertEqual(course._get_subject_courses("CS"), mocked_courses_data)
+        self.assertEqual(course._get_course_info("105611"), mocked_course_info_data)
+        self.assertEqual(course._get_course_sections("105611", "2231"), mocked_course_sections_data)
+        self.assertEqual(course._get_section_details("2231", "27815"), mocked_section_details_data)
+
+    @responses.activate
+    def test_course_http_helper_errors(self):
+        responses.add(
+            responses.GET,
+            course.COURSE_DETAIL_API.format(id="invalid"),
+            json={"course_details": {}},
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            course.COURSE_SECTIONS_API.format(id="invalid", term="2231"),
+            json={"sections": []},
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            course.SECTION_DETAILS_API.format(term="2231", id="invalid"),
+            json={"error": "invalid"},
+            status=200,
+        )
+
+        with self.assertRaisesRegex(ValueError, "Invalid course ID"):
+            course._get_course_info("invalid")
+        with self.assertRaisesRegex(ValueError, "Invalid course ID"):
+            course._get_course_sections("invalid", "2231")
+        with self.assertRaisesRegex(ValueError, "Invalid section ID"):
+            course._get_section_details("2231", "invalid")

--- a/tests/dining_test.py
+++ b/tests/dining_test.py
@@ -21,6 +21,7 @@ import json
 import unittest
 import responses
 import datetime
+from unittest.mock import patch
 
 from pathlib import Path
 
@@ -91,3 +92,80 @@ class DiningTest(unittest.TestCase):
         )
         locations = dining.get_location_menu("The Eatery", datetime.datetime(2024, 4, 12), "Breakfast")
         self.assertIsInstance(locations, dict)
+
+    def test_invalid_location_names(self):
+        with self.assertRaisesRegex(ValueError, "Invalid Dining Location"):
+            dining.get_location_hours("Not A Dining Location", datetime.datetime(2024, 4, 12))
+        with self.assertRaisesRegex(ValueError, "Invalid Dining Location"):
+            dining.get_location_menu("Not A Dining Location", datetime.datetime(2024, 4, 12))
+
+    @responses.activate
+    def test_get_all_location_hours_with_default_date(self):
+        responses.add(
+            responses.GET,
+            dining.HOURS_URL.format(date_str="2024-04-12"),
+            json=self.dining_schedule_data,
+            status=200,
+        )
+
+        with patch.object(dining, "datetime") as mock_datetime:
+            mock_datetime.now.return_value = datetime.datetime(2024, 4, 12)
+            hours = dining.get_location_hours()
+
+        self.assertIn("The Eatery", hours)
+
+    @responses.activate
+    def test_get_location_hours_errors_and_missing_location(self):
+        responses.add(
+            responses.GET,
+            dining.HOURS_URL.format(date_str="2024-04-12"),
+            status=502,
+        )
+        with self.assertRaisesRegex(ValueError, "Invalid Date"):
+            dining.get_location_hours("The Eatery", datetime.datetime(2024, 4, 12))
+
+        responses.add(
+            responses.GET,
+            dining.HOURS_URL.format(date_str="2024-04-13"),
+            json={"the_locations": []},
+            status=200,
+        )
+        self.assertEqual(dining.get_location_hours("The Eatery", datetime.datetime(2024, 4, 13)), {})
+
+    @responses.activate
+    def test_get_location_menu_with_default_date_and_period(self):
+        responses.add(responses.GET, dining.LOCATIONS_URL, json=self.dining_locations_data, status=200)
+        responses.add(
+            responses.GET,
+            dining.PERIODS_URL.format(location_id="610b1f78e82971147c9f8ba5", date_str="24-04-12"),
+            json=self.dining_menu_data,
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            dining.MENU_URL.format(
+                location_id="610b1f78e82971147c9f8ba5",
+                period_id="659daa4d351d53068df67835",
+                date_str="24-04-12",
+            ),
+            json=self.dining_menu_data,
+            status=200,
+        )
+
+        with patch.object(dining, "datetime") as mock_datetime:
+            mock_datetime.today.return_value = datetime.datetime(2024, 4, 12)
+            menu = dining.get_location_menu("The Eatery")
+
+        self.assertEqual(menu, self.dining_menu_data["menu"])
+
+    @responses.activate
+    def test_get_location_menu_invalid_date(self):
+        responses.add(responses.GET, dining.LOCATIONS_URL, json=self.dining_locations_data, status=200)
+        responses.add(
+            responses.GET,
+            dining.PERIODS_URL.format(location_id="610b1f78e82971147c9f8ba5", date_str="24-04-12"),
+            status=502,
+        )
+
+        with self.assertRaisesRegex(ValueError, "Invalid Date"):
+            dining.get_location_menu("The Eatery", datetime.datetime(2024, 4, 12))

--- a/tests/lab_test.py
+++ b/tests/lab_test.py
@@ -251,3 +251,32 @@ class LabTest(unittest.TestCase):
             match="An unexpected error occurred while fetching lab data: Unauthorized",
         ):
             lab.get_one_lab_data("CATH_G27")
+
+    @responses.activate
+    def test_out_of_service_computer(self):
+        responses.add(
+            responses.GET,
+            create_test_url("BELLEFIELD"),
+            json={
+                "hours": {"Test Lab": {"closed": False}},
+                "state": {"computer": {"up": 3, "addr": "computer.example.edu"}},
+            },
+        )
+
+        result = lab.get_one_lab_data("BELLEFIELD")
+
+        self.assertEqual(result.out_of_service_computers, 1)
+
+    @responses.activate
+    def test_unknown_computer_state(self):
+        responses.add(
+            responses.GET,
+            create_test_url("BELLEFIELD"),
+            json={
+                "hours": {"Test Lab": {"closed": False}},
+                "state": {"computer": {"up": 99, "addr": "computer.example.edu"}},
+            },
+        )
+
+        with pytest.raises(lab.LabAPIError, match="Unknown 'up' value for computer.example.edu"):
+            lab.get_one_lab_data("BELLEFIELD")

--- a/tests/laundry_test.py
+++ b/tests/laundry_test.py
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 import unittest
 import responses
 import json
+from unittest.mock import patch
 
 from pathlib import Path
 
@@ -104,3 +105,34 @@ class LaundryTest(unittest.TestCase):
                 self.assertIsNone(machine.time_left)
             else:
                 self.fail(f"Invalid machine status detected for {machine=}")
+
+    def test_combo_machine_rejects_invalid_first_name(self):
+        with self.assertRaisesRegex(ValueError, "invalid machine name"):
+            laundry._parse_laundry_object_json({"type": "washNdry", "appliance_desc": "Washer without a number"})
+
+    def test_combo_machine_rejects_invalid_second_name(self):
+        machine = {
+            "type": "washNdry",
+            "appliance_desc": "Washer 2",
+            "appliance_desc_key": "washer-2",
+            "time_left_lite": "Available",
+            "time_remaining": 0,
+            "appliance_desc2": "Dryer without a number",
+        }
+
+        with self.assertRaisesRegex(ValueError, "invalid machine name"):
+            laundry._parse_laundry_object_json(machine)
+
+    def test_building_status_ignores_unknown_machine_type(self):
+        machine = laundry.LaundryMachine(
+            name="Card Reader",
+            id="reader",
+            status="Available",
+            type="other",
+            time_left=None,
+        )
+
+        with patch.object(laundry, "get_laundry_machine_statuses", return_value=[machine]):
+            status = laundry.get_building_status("TOWERS")
+
+        self.assertEqual(status, BuildingStatus("TOWERS", 0, 0, 0, 0))

--- a/tests/library_test.py
+++ b/tests/library_test.py
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 import json
 import unittest
+from copy import deepcopy
 from pathlib import Path
 
 import responses
@@ -45,6 +46,45 @@ class LibraryTest(unittest.TestCase):
         query_result = library.get_documents("water")
         self.assertEqual(query_result.num_pages, 10)
         self.assertEqual(len(query_result.docs), 10)
+
+    @responses.activate
+    def test_get_document_by_bookmark(self):
+        responses.add(
+            responses.GET,
+            library.LIBRARY_URL + "&bookMark=valid",
+            json=self.library_query,
+            status=200,
+        )
+
+        query_result = library.get_document_by_bookmark("valid")
+
+        self.assertEqual(query_result.num_pages, 10)
+        self.assertEqual(len(query_result.docs), 10)
+
+    @responses.activate
+    def test_get_document_by_bookmark_rejects_invalid_bookmark(self):
+        responses.add(
+            responses.GET,
+            library.LIBRARY_URL + "&bookMark=invalid",
+            json={"errors": [{"code": "invalid.bookmark.format"}]},
+            status=200,
+        )
+
+        with self.assertRaisesRegex(ValueError, "Invalid bookmark"):
+            library.get_document_by_bookmark("invalid")
+
+    @responses.activate
+    def test_get_document_by_bookmark_ignores_unrelated_errors(self):
+        response_data = deepcopy(self.library_query)
+        response_data["errors"] = [{"code": "unrelated.error"}]
+        responses.add(
+            responses.GET,
+            library.LIBRARY_URL + "&bookMark=other",
+            json=response_data,
+            status=200,
+        )
+
+        self.assertEqual(library.get_document_by_bookmark("other").num_pages, 10)
 
 
 class StudyRoomTest(unittest.TestCase):
@@ -94,3 +134,14 @@ class StudyRoomTest(unittest.TestCase):
             ),
         ]
         self.assertEqual(mock_answer, library.reserved_hillman_times())
+
+    @responses.activate
+    def test_reserved_hillman_times_with_no_data(self):
+        responses.add(
+            responses.GET,
+            library.STUDY_ROOMS_URL,
+            json={"data": None},
+            status=200,
+        )
+
+        self.assertEqual(library.reserved_hillman_times(), [])

--- a/tests/news_test.py
+++ b/tests/news_test.py
@@ -242,3 +242,31 @@ class NewsTest(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "missing its heading or description"):
             news.get_articles_by_topic("university-news")
+
+    @responses.activate
+    def test_get_articles_by_topic_rejects_card_without_url(self):
+        responses.add(
+            responses.GET,
+            "https://www.pitt.edu/pittwire/news/features-articles?field_topics_target_id=432&field_article_date_value=&title="
+            "&field_category_target_id=All",
+            body=(
+                "<html><body><div><main><div><section><div class='news-card'>"
+                "<h2 class='news-card-title'><a>Title</a></h2><p>Description</p>"
+                "</div></section></div></main></div></body></html>"
+            ),
+        )
+
+        with self.assertRaisesRegex(ValueError, "missing its URL"):
+            news.get_articles_by_topic("university-news")
+
+    @responses.activate
+    def test_get_articles_by_topic_rejects_page_without_main_content(self):
+        responses.add(
+            responses.GET,
+            "https://www.pitt.edu/pittwire/news/features-articles?field_topics_target_id=432&field_article_date_value=&title="
+            "&field_category_target_id=All",
+            body="<html><body></body></html>",
+        )
+
+        with self.assertRaisesRegex(ValueError, "missing its main content"):
+            news.get_articles_by_topic("university-news")

--- a/tests/people_test.py
+++ b/tests/people_test.py
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 import unittest
 import responses
+from bs4 import BeautifulSoup
 
 from pathlib import Path
 
@@ -59,3 +60,28 @@ class PeopleTest(unittest.TestCase):
         ans = people.get_person("Lebron Iverson James Jordan Kobe")
         self.assertIsInstance(ans, list)
         self.assertEqual(ans, [{"ERROR": "No one found."}])
+
+    def test_parse_segments_handles_empty_unknown_and_repeated_labels(self):
+        soup = BeautifulSoup(
+            """
+            <div>
+                <span class="row-label"></span>
+                <span>Ignored</span>
+                <span class="row-label">Unknown Label</span>
+                <span>Also ignored</span>
+                <span class="row-label">Email</span>
+                <span>first@example.edu</span>
+                <span>second@example.edu</span>
+                <span>third@example.edu</span>
+            </div>
+            """,
+            "html.parser",
+        )
+        person = {}
+
+        people._parse_segments(person, soup.select("span"))
+
+        self.assertEqual(
+            person,
+            {"email": ["first@example.edu", "second@example.edu", "third@example.edu"]},
+        )

--- a/tests/people_test.py
+++ b/tests/people_test.py
@@ -25,7 +25,6 @@ from pathlib import Path
 
 from pittapi import people
 
-
 SAMPLE_PATH = Path() / "tests" / "samples"
 
 

--- a/tests/sports_test.py
+++ b/tests/sports_test.py
@@ -14,15 +14,17 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 
+from copy import deepcopy
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import patch
 
+import responses
 from pittapi import sports
 
 
 class LibraryTest(unittest.TestCase):
     def setUp(self):
-        mocked_basketball_data = {
+        self.mocked_basketball_data = {
             "team": {
                 "id": "221",
                 "record": {
@@ -80,7 +82,7 @@ class LibraryTest(unittest.TestCase):
                 "standingSummary": "12th in ACC",
             }
         }
-        mocked_football_data = {
+        self.mocked_football_data = {
             "team": {
                 "id": "221",
                 "name": "Pittsburgh",
@@ -141,15 +143,27 @@ class LibraryTest(unittest.TestCase):
                 "standingSummary": "1st in ACC - Coastal",
             }
         }
-        sports._get_mens_basketball_data = MagicMock(return_value=mocked_basketball_data)
-        sports._get_football_data = MagicMock(return_value=mocked_football_data)
+        basketball_patcher = patch.object(
+            sports,
+            "_get_mens_basketball_data",
+            return_value=self.mocked_basketball_data,
+        )
+        football_patcher = patch.object(
+            sports,
+            "_get_football_data",
+            return_value=self.mocked_football_data,
+        )
+        self.mock_get_basketball_data = basketball_patcher.start()
+        self.mock_get_football_data = football_patcher.start()
+        self.addCleanup(basketball_patcher.stop)
+        self.addCleanup(football_patcher.stop)
 
     def test_get_mens_basketball_record(self):
         self.assertEqual("11-21", sports.get_mens_basketball_record())
 
     def test_get_mens_basketball_record_offseason(self):
         offseason_data = {"team": {"id": "221", "record": {}}}
-        sports._get_mens_basketball_data = MagicMock(return_value=offseason_data)
+        self.mock_get_basketball_data.return_value = offseason_data
 
         self.assertEqual("There's no record right now.", sports.get_mens_basketball_record())
 
@@ -158,7 +172,7 @@ class LibraryTest(unittest.TestCase):
 
     def test_get_football_record_offseason(self):
         offseason_data = {"team": {"id": "221", "record": {}}}
-        sports._get_football_data = MagicMock(return_value=offseason_data)
+        self.mock_get_football_data.return_value = offseason_data
 
         self.assertEqual("There's no record right now.", sports.get_football_record())
 
@@ -170,15 +184,19 @@ class LibraryTest(unittest.TestCase):
 
     def test_get_next_mens_basketball_game(self):
         next_game_details = sports.get_next_mens_basketball_game()
-        self.assertNotEqual("NO_GAME_SCHEDULED", next_game_details.status)
+        self.assertEqual("GAME_COMPLETE", next_game_details.status)
+        self.assertEqual("103", next_game_details.opponent["id"])
+        self.assertEqual("home", next_game_details.home_away)
 
     def test_get_next_football_game(self):
         next_game_details = sports.get_next_football_game()
-        self.assertNotEqual("NO_GAME_SCHEDULED", next_game_details.status)
+        self.assertEqual("IN_PROGRESS", next_game_details.status)
+        self.assertEqual("103", next_game_details.opponent["id"])
+        self.assertEqual("away", next_game_details.home_away)
 
     def test_get_next_mens_basketball_game_offseason(self):
         offseason_data = {"team": {"nextEvent": []}}
-        sports._get_mens_basketball_data = MagicMock(return_value=offseason_data)
+        self.mock_get_basketball_data.return_value = offseason_data
 
         next_game_details = sports.get_next_mens_basketball_game()
         self.assertIsNone(next_game_details.timestamp)
@@ -189,7 +207,7 @@ class LibraryTest(unittest.TestCase):
 
     def test_get_next_football_game_offseason(self):
         offseason_data = {"team": {"nextEvent": []}}
-        sports._get_football_data = MagicMock(return_value=offseason_data)
+        self.mock_get_football_data.return_value = offseason_data
 
         next_game_details = sports.get_next_football_game()
         self.assertIsNone(next_game_details.timestamp)
@@ -197,3 +215,55 @@ class LibraryTest(unittest.TestCase):
         self.assertIsNone(next_game_details.home_away)
         self.assertIsNone(next_game_details.location)
         self.assertEqual("NO_GAME_SCHEDULED", next_game_details.status)
+
+    def test_basketball_in_progress_with_pitt_second(self):
+        basketball_data = deepcopy(self.mocked_basketball_data)
+        competition = basketball_data["team"]["nextEvent"][0]["competitions"][0]
+        competition["status"]["type"]["name"] = "STATUS_IN_PROGRESS"
+        competition["competitors"].reverse()
+        self.mock_get_basketball_data.return_value = basketball_data
+
+        game = sports.get_next_mens_basketball_game()
+
+        self.assertEqual(game.status, "IN_PROGRESS")
+        self.assertEqual(game.opponent["id"], "103")
+        self.assertEqual(game.home_away, "home")
+
+    def test_basketball_scheduled_game(self):
+        basketball_data = deepcopy(self.mocked_basketball_data)
+        basketball_data["team"]["nextEvent"][0]["competitions"][0]["status"]["type"]["name"] = "STATUS_SCHEDULED"
+        self.mock_get_basketball_data.return_value = basketball_data
+
+        self.assertIsNone(sports.get_next_mens_basketball_game().status)
+
+    def test_football_final_game(self):
+        football_data = deepcopy(self.mocked_football_data)
+        football_data["team"]["nextEvent"][0]["competitions"][0]["status"]["type"]["name"] = "STATUS_FINAL"
+        self.mock_get_football_data.return_value = football_data
+
+        self.assertEqual(sports.get_next_football_game().status, "GAME_COMPLETE")
+
+    def test_football_scheduled_with_pitt_second(self):
+        football_data = deepcopy(self.mocked_football_data)
+        competition = football_data["team"]["nextEvent"][0]["competitions"][0]
+        competition["status"]["type"]["name"] = "STATUS_SCHEDULED"
+        competition["competitors"].reverse()
+        self.mock_get_football_data.return_value = football_data
+
+        game = sports.get_next_football_game()
+
+        self.assertIsNone(game.status)
+        self.assertEqual(game.opponent["id"], "103")
+        self.assertEqual(game.home_away, "away")
+
+
+class SportsHttpHelperTest(unittest.TestCase):
+    @responses.activate
+    def test_sports_http_helpers(self):
+        basketball_data = {"team": {"id": "221"}}
+        football_data = {"team": {"id": "221"}}
+        responses.add(responses.GET, sports.MENS_BASKETBALL_URL, json=basketball_data, status=200)
+        responses.add(responses.GET, sports.FOOTBALL_URL, json=football_data, status=200)
+
+        self.assertEqual(sports._get_mens_basketball_data(), basketball_data)
+        self.assertEqual(sports._get_football_data(), football_data)

--- a/tests/textbook_test.py
+++ b/tests/textbook_test.py
@@ -198,6 +198,17 @@ class TextbookTest(unittest.TestCase):
 
         self.assertRaises(ConnectionError, textbook.CourseInfo, "CS", "0441", instructor="GARRISON III")
 
+    @responses.activate
+    def test_update_headers_rejects_csrf_meta_without_content(self):
+        responses.add(
+            responses.GET,
+            "https://pitt.verbacompare.com/",
+            body="<html><head><meta name='csrf-token'></head></html>",
+        )
+
+        with self.assertRaises(ConnectionError):
+            textbook._update_headers()
+
     @mark.filterwarnings("ignore:Attempt")
     @responses.activate
     def test_course_info_failing_subject_map_requests(self):
@@ -205,6 +216,15 @@ class TextbookTest(unittest.TestCase):
         self.mock_subject_map_failure()
 
         self.assertRaises(ConnectionError, textbook.CourseInfo, "CS", "0441", instructor="GARRISON III")
+
+    @responses.activate
+    def test_update_subject_map_with_existing_headers(self):
+        textbook.request_headers = {"X-CSRF-Token": CSRF_TOKEN}
+        self.mock_subject_map_success()
+
+        textbook._update_subject_map()
+
+        self.assertEqual(textbook.subject_map["CS"], CS_SUBJECT_ID)
 
     def test_textbook_from_json(self):
         self.assertEqual(len(self.cs_0441_textbook_data), 1)
@@ -415,6 +435,54 @@ class TextbookTest(unittest.TestCase):
 
         with self.assertRaises(HTTPError):
             textbook._get_textbooks_for_ids([CS_0441_GARRISON_SECTION_ID])
+
+    @responses.activate
+    def test_get_textbooks_for_ids_initializes_headers(self):
+        self.mock_base_site_success()
+        self.mock_cs_0441_garrison_books_success()
+
+        books = textbook._get_textbooks_for_ids([CS_0441_GARRISON_SECTION_ID])
+
+        self.assertEqual(len(books), 1)
+        self.assertEqual(textbook.request_headers, {"X-CSRF-Token": CSRF_TOKEN})
+
+    @responses.activate
+    def test_get_textbooks_for_course_initializes_headers(self):
+        self.mock_base_site_success()
+        self.mock_subject_map_success()
+        course_info = textbook.CourseInfo("CS", "0441", instructor="GARRISON III")
+        textbook.request_headers = None
+        self.mock_base_site_success()
+        self.mock_cs_courses_success()
+        self.mock_cs_0441_garrison_books_success()
+
+        self.assertEqual(len(textbook.get_textbooks_for_course(course_info)), 1)
+
+    @responses.activate
+    def test_get_textbooks_for_course_initializes_subject_map(self):
+        self.mock_base_site_success()
+        self.mock_subject_map_success()
+        course_info = textbook.CourseInfo("CS", "0441", instructor="GARRISON III")
+        textbook.subject_map = None
+        self.mock_subject_map_success()
+        self.mock_cs_courses_success()
+        self.mock_cs_0441_garrison_books_success()
+
+        self.assertEqual(len(textbook.get_textbooks_for_course(course_info)), 1)
+
+    @responses.activate
+    def test_get_textbooks_for_courses_initializes_global_state(self):
+        self.mock_base_site_success()
+        self.mock_subject_map_success()
+        course_info = textbook.CourseInfo("CS", "0441", instructor="GARRISON III")
+        textbook.request_headers = None
+        textbook.subject_map = None
+        self.mock_base_site_success()
+        self.mock_subject_map_success()
+        self.mock_cs_courses_success()
+        self.mock_cs_0441_garrison_books_success()
+
+        self.assertEqual(len(textbook.get_textbooks_for_courses([course_info])), 1)
 
     @mark.filterwarnings("ignore:Attempt")
     @responses.activate


### PR DESCRIPTION
Expands the deterministic unit suite to cover every existing statement and branch before the 2.0 refactor.
Live network access is explicitly blocked in unit tests, and HTTP-facing behavior is exercised with mocked responses.