### PR TITLE
Move to a base client for requests

### DIFF
--- a/pittapi/base_client.py
+++ b/pittapi/base_client.py
@@ -1,0 +1,63 @@
+"""
+The Pitt API, to access workable data of the University of Pittsburgh
+Copyright (C) 2015 Ritwik Gupta
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Shared HTTP lifecycle for PittAPI service clients.
+"""
+
+from __future__ import annotations
+
+from types import TracebackType
+from typing import Any, Self
+
+import requests
+
+__all__ = ["BaseClient"]
+
+
+class BaseClient:
+    """Own a requests session and apply one timeout policy consistently."""
+
+    def __init__(self, session: requests.Session | None = None, timeout: float = 10.0) -> None:
+        if timeout <= 0:
+            raise ValueError("timeout must be greater than zero")
+        self.session = session or requests.Session()
+        self.timeout = timeout
+        self.owns_session = session is None
+
+    def request(self, method: str, url: str, **kwargs: Any) -> requests.Response:
+        """Send a request, enforce the configured timeout, and check its status."""
+        kwargs.setdefault("timeout", self.timeout)
+        response = self.session.request(method, url, **kwargs)
+        response.raise_for_status()
+        return response
+
+    def close(self) -> None:
+        """Close a session created by this client."""
+        if self.owns_session:
+            self.session.close()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        exception_type: type[BaseException] | None,
+        exception: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.close()

--- a/pittapi/cal.py
+++ b/pittapi/cal.py
@@ -15,64 +15,75 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Academic calendar data published by the University of Pittsburgh.
 """
 
-from typing import NamedTuple
+from dataclasses import dataclass
+from typing import Any
 
-import requests
+from pittapi.base_client import BaseClient
+
+__all__ = ["CalendarClient", "Event"]
+
+ACADEMIC_CALENDAR_URL = "https://25livepub.collegenet.com/calendars/pitt-academic-calendar.json"
+GRADES_CALENDAR_URL = "https://25livepub.collegenet.com/calendars/pitt-grades-calendar.json"
+ENROLLMENT_CALENDAR_URL = "https://25livepub.collegenet.com/calendars/pitt-enrollment-calendar.json"
+COURSE_CALENDAR_URL = "https://25livepub.collegenet.com/calendars/pitt-courseclass-calendar.json"
+GRADUATION_CALENDAR_URL = "https://25livepub.collegenet.com/calendars/pitt-graduation-calendar.json"
 
 
-class Event(NamedTuple):
+@dataclass(frozen=True, slots=True)
+class Event:
+    """One event from a Pitt calendar."""
+
     date: str
     title: str
     content: str
-    meta: list[str]
+    categories: tuple[str, ...]
 
 
-ACADEMIC_CALENDAR_URL: str = "https://25livepub.collegenet.com/calendars/pitt-academic-calendar.json"
-GRADES_CALENDAR_URL: str = "https://25livepub.collegenet.com/calendars/pitt-grades-calendar.json"
-ENROLLMENT_CALENDAR_URL: str = "https://25livepub.collegenet.com/calendars/pitt-enrollment-calendar.json"
-COURSE_CALENDAR_URL: str = "https://25livepub.collegenet.com/calendars/pitt-courseclass-calendar.json"
-GRADUATION_CALENDAR_URL: str = "https://25livepub.collegenet.com/calendars/pitt-graduation-calendar.json"
+class CalendarClient(BaseClient):
+    """Fetch events from Pitt's public calendars."""
+
+    def get_academic_calendar(self) -> tuple[Event, ...]:
+        return self.fetch_events(ACADEMIC_CALENDAR_URL)
+
+    def get_grades_calendar(self) -> tuple[Event, ...]:
+        return self.fetch_events(GRADES_CALENDAR_URL)
+
+    def get_enrollment_calendar(self) -> tuple[Event, ...]:
+        return self.fetch_events(ENROLLMENT_CALENDAR_URL)
+
+    def get_course_calendar(self) -> tuple[Event, ...]:
+        """Return dates on which courses for future terms are determined."""
+        return self.fetch_events(COURSE_CALENDAR_URL)
+
+    def get_graduation_calendar(self) -> tuple[Event, ...]:
+        return self.fetch_events(GRADUATION_CALENDAR_URL)
+
+    def fetch_events(self, url: str) -> tuple[Event, ...]:
+        data = self.request("GET", url).json()
+        if not isinstance(data, list):
+            raise ValueError("calendar response must contain a list of events")
+
+        events = []
+        for raw_event in data:
+            events.append(parse_event(raw_event))
+        return tuple(events)
 
 
-def _fetch_calendar_events(url: str) -> list[Event]:
-    """"""
-    data = requests.get(url).json()
-    events = []
-    for calendar_event in data:
-        assert calendar_event["customFields"][0]["label"] == "Event Title"
-        event = Event(
-            title=calendar_event["title"],
-            date=calendar_event["startDateTime"][:10],
-            content=calendar_event["customFields"][0]["value"],
-            meta=calendar_event["categoryCalendar"].split("|"),
+def parse_event(raw_event: dict[str, Any]) -> Event:
+    """Convert one provider event into PittAPI's supported event model."""
+    try:
+        event_field = raw_event["customFields"][0]
+        if event_field["label"] != "Event Title":
+            raise ValueError("calendar event has an unexpected custom field")
+        return Event(
+            title=raw_event["title"],
+            date=raw_event["startDateTime"][:10],
+            content=event_field["value"],
+            categories=tuple(raw_event["categoryCalendar"].split("|")),
         )
-        events.append(event)
-    return events
-
-
-def get_academic_calendar() -> list[Event]:
-    """"""
-    return _fetch_calendar_events(ACADEMIC_CALENDAR_URL)
-
-
-def get_grades_calendar() -> list[Event]:
-    """"""
-    return _fetch_calendar_events(GRADES_CALENDAR_URL)
-
-
-def get_enrollment_calendar() -> list[Event]:
-    """"""
-    return _fetch_calendar_events(ENROLLMENT_CALENDAR_URL)
-
-
-def get_course_calendar() -> list[Event]:
-    """This is not a calendar about course schedule but rather
-    when courses/class are being determined for the next semester"""
-    return _fetch_calendar_events(COURSE_CALENDAR_URL)
-
-
-def get_graduation_calendar() -> list[Event]:
-    """"""
-    return _fetch_calendar_events(GRADUATION_CALENDAR_URL)
+    except (KeyError, IndexError, TypeError) as error:
+        raise ValueError("calendar event is missing required data") from error

--- a/pittapi/gym.py
+++ b/pittapi/gym.py
@@ -15,71 +15,64 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Current occupancy for Pitt recreation facilities.
 """
 
 from __future__ import annotations
 
-from bs4 import BeautifulSoup
-import requests
-from typing import NamedTuple
+from dataclasses import dataclass
 
-GYM_URL = "https://connect2concepts.com/connect2/?type=bar&key=17c2cbcb-ec92-4178-a5f5-c4860330aea0"
+from pittapi.base_client import BaseClient
 
-GYM_NAMES = [
-    "Baierl Rec Center",
-    "Bellefield Hall: Fitness Center & Weight Room",
-    "Bellefield Hall: Court & Dance Studio",
-    "Trees Hall: Fitness Center",
-    "Trees Hall: Courts",
-    "Trees Hall: Racquetball Courts & Multipurpose Room",
-    "William Pitt Union",
-    "Pitt Sports Dome",
-]
+__all__ = ["Gym", "GymClient"]
+
+GYM_URL = "https://goboardapi.azurewebsites.net/api/FacilityCount/GetCountsByAccount"
+PITT_ACCOUNT_KEY = "17c2cbcb-ec92-4178-a5f5-c4860330aea0"
 
 
-class Gym(NamedTuple):
-    name: str
-    last_updated: str | None = None
-    current_count: int | None = None
-    percent_full: int | None = None
+@dataclass(frozen=True, slots=True)
+class Gym:
+    """Occupancy information for one recreation facility."""
 
-    @classmethod
-    def from_text(cls, text: str) -> Gym:
-        info = text.split("|")
-        name = info[0]
-        if len(info) < 4:
-            return cls(name=name)
-        count = int(info[2][12:])
-        date_time = info[3][9:]
+    location_id: int
+    location_name: str
+    facility_id: int
+    facility_name: str
+    total_capacity: int
+    current_count: int
+    percent_full: int
+    last_updated: str
+    is_closed: bool
+
+
+class GymClient(BaseClient):
+    """Fetch recreation facility occupancy."""
+
+    def get_all_gyms_info(self) -> tuple[Gym, ...]:
+        data = self.request("GET", GYM_URL, params={"AccountAPIKey": PITT_ACCOUNT_KEY}).json()
+        if not isinstance(data, list):
+            raise ValueError("gym response must contain a list")
         try:
-            percentage = int(info[4].rstrip("%"))
-        except ValueError:
-            percentage = 0
+            return tuple(
+                Gym(
+                    location_id=item["LocationId"],
+                    location_name=item["LocationName"],
+                    facility_id=item["FacilityId"],
+                    facility_name=item["FacilityName"],
+                    total_capacity=item["TotalCapacity"],
+                    current_count=item["LastCount"],
+                    percent_full=item["PercetageCapacity"],
+                    last_updated=item["LastUpdatedDateAndTime"],
+                    is_closed=item["IsClosed"],
+                )
+                for item in data
+            )
+        except (KeyError, TypeError) as error:
+            raise ValueError("gym response is missing required data") from error
 
-        return cls(name=name, last_updated=date_time, current_count=count, percent_full=percentage)
-
-
-def get_all_gyms_info() -> list[Gym]:
-    """Fetches list of Gym named tuples with all gym information"""
-    # Was getting a Mod Security Error
-    # Fix: https://stackoverflow.com/questions/61968521/python-web-scraping-request-errormod-security
-    headers = {
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0",
-    }
-
-    page = requests.get(GYM_URL, headers=headers)
-    soup = BeautifulSoup(page.text, "html.parser")
-    gym_info_list = soup.find_all("div", class_="barChart")
-
-    gyms = [Gym.from_text(gym.get_text("|", strip=True)) for gym in gym_info_list]
-    return gyms
-
-
-def get_gym_info(gym_name: str) -> Gym | None:
-    """Fetches the information of a singular gym as a tuple"""
-    info = get_all_gyms_info()
-    if gym_name in GYM_NAMES:
-        for gym in info:
-            if gym.name == gym_name and gym.last_updated and gym.current_count and gym.percent_full:
+    def get_gym_info(self, gym_name: str) -> Gym:
+        for gym in self.get_all_gyms_info():
+            if gym.location_name == gym_name:
                 return gym
-    return None
+        raise LookupError(f"gym not found: {gym_name}")

--- a/pittapi/status.py
+++ b/pittapi/status.py
@@ -15,60 +15,112 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Operational status for Pitt technology services.
 """
 
-import requests
+from dataclasses import dataclass
 from typing import Any
 
+from pittapi.base_client import BaseClient
 
-def get_status() -> dict[str, list[Any]]:
-    """Gets status information about all Pitt services"""
-    status = requests.get("https://status.pitt.edu/index.json")
-    data = status.json()
-    components = [
-        {
-            "status": component["status"],
-            "name": component["name"],
-            "updated_at": component["updated_at"],
-            "description": component["description"],
-        }
-        for component in data["components"]
-    ]
-    incidents = [
-        {
-            "components": [
-                {
-                    "status": component["status"],
-                    "name": component["name"],
-                    "updated_at": component["updated_at"],
-                    "description": component["description"],
-                }
-                for component in incident["components"]
-            ],
-            "incident_updates": [
-                {
-                    "affected_components": [
-                        {
-                            "name": component["name"],
-                            "new_status": component["new_status"],
-                            "old_status": component["old_status"],
-                        }
-                        for component in update["affected_components"]
-                    ],
-                    "body": update["body"],
-                    "status": update["status"],
-                    "updated_at": update["updated_at"],
-                }
-                for update in incident["incident_updates"]
-            ],
-            "impact": incident["impact"],
-            "name": incident["name"],
-            "status": incident["status"],
-            "resolved_at": incident["resolved_at"],
-            "updated_at": incident["updated_at"],
-        }
-        for incident in data["incidents"]
-    ]
-    ret = {"components": components, "incidents": incidents}
+__all__ = [
+    "AffectedComponent",
+    "Component",
+    "Incident",
+    "IncidentUpdate",
+    "StatusClient",
+    "StatusSummary",
+]
 
-    return ret
+STATUS_URL = "https://status.pitt.edu/index.json"
+
+
+@dataclass(frozen=True, slots=True)
+class Component:
+    status: str
+    name: str
+    updated_at: str
+    description: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class AffectedComponent:
+    name: str
+    new_status: str
+    old_status: str
+
+
+@dataclass(frozen=True, slots=True)
+class IncidentUpdate:
+    affected_components: tuple[AffectedComponent, ...]
+    body: str
+    status: str
+    updated_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class Incident:
+    components: tuple[Component, ...]
+    incident_updates: tuple[IncidentUpdate, ...]
+    impact: str
+    name: str
+    status: str
+    resolved_at: str | None
+    updated_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class StatusSummary:
+    components: tuple[Component, ...]
+    incidents: tuple[Incident, ...]
+
+
+class StatusClient(BaseClient):
+    """Fetch Pitt's current service status."""
+
+    def get_status(self) -> StatusSummary:
+        data = self.request("GET", STATUS_URL).json()
+        try:
+            components = tuple(parse_component(item) for item in data["components"])
+            incidents = tuple(parse_incident(item) for item in data["incidents"])
+        except (KeyError, TypeError) as error:
+            raise ValueError("status response is missing required data") from error
+        return StatusSummary(components=components, incidents=incidents)
+
+
+def parse_component(data: dict[str, Any]) -> Component:
+    return Component(
+        status=data["status"],
+        name=data["name"],
+        updated_at=data["updated_at"],
+        description=data["description"],
+    )
+
+
+def parse_affected_component(data: dict[str, Any]) -> AffectedComponent:
+    return AffectedComponent(name=data["name"], new_status=data["new_status"], old_status=data["old_status"])
+
+
+def parse_incident_update(data: dict[str, Any]) -> IncidentUpdate:
+    affected_components = tuple(parse_affected_component(item) for item in (data["affected_components"] or ()))
+    return IncidentUpdate(
+        affected_components=affected_components,
+        body=data["body"],
+        status=data["status"],
+        updated_at=data["updated_at"],
+    )
+
+
+def parse_incident(data: dict[str, Any]) -> Incident:
+    components = tuple(parse_component(item) for item in data["components"])
+    updates = tuple(parse_incident_update(item) for item in data["incident_updates"])
+    return Incident(
+        components=components,
+        incident_updates=updates,
+        impact=data["impact"],
+        name=data["name"],
+        status=data["status"],
+        resolved_at=data["resolved_at"],
+        updated_at=data["updated_at"],
+    )

--- a/tests/base_client_test.py
+++ b/tests/base_client_test.py
@@ -1,0 +1,48 @@
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from pittapi.base_client import BaseClient
+
+
+def test_timeout_must_be_positive():
+    with pytest.raises(ValueError, match="greater than zero"):
+        BaseClient(timeout=0)
+
+
+def test_request_applies_timeout_and_checks_status():
+    session = Mock(spec=requests.Session)
+    response = Mock(spec=requests.Response)
+    session.request.return_value = response
+    client = BaseClient(session=session, timeout=4)
+
+    assert client.request("GET", "https://example.test") is response
+    session.request.assert_called_once_with("GET", "https://example.test", timeout=4)
+    response.raise_for_status.assert_called_once_with()
+
+
+def test_request_preserves_explicit_timeout():
+    session = Mock(spec=requests.Session)
+    session.request.return_value = Mock(spec=requests.Response)
+
+    BaseClient(session=session).request("GET", "https://example.test", timeout=2)
+
+    session.request.assert_called_once_with("GET", "https://example.test", timeout=2)
+
+
+def test_injected_session_is_not_closed():
+    session = Mock(spec=requests.Session)
+    with BaseClient(session=session) as client:
+        assert client.session is session
+    session.close.assert_not_called()
+
+
+def test_owned_session_is_closed(monkeypatch):
+    session = Mock(spec=requests.Session)
+    monkeypatch.setattr(requests, "Session", Mock(return_value=session))
+
+    client = BaseClient()
+    client.close()
+
+    session.close.assert_called_once_with()

--- a/tests/cal_test.py
+++ b/tests/cal_test.py
@@ -1,40 +1,62 @@
-import unittest
-
+import pytest
 import responses
 
-from pittapi import cal
+from pittapi.cal import (
+    ACADEMIC_CALENDAR_URL,
+    COURSE_CALENDAR_URL,
+    ENROLLMENT_CALENDAR_URL,
+    GRADES_CALENDAR_URL,
+    GRADUATION_CALENDAR_URL,
+    CalendarClient,
+    Event,
+    parse_event,
+)
+
+EVENT_DATA = {
+    "title": "Fall term begins",
+    "startDateTime": "2026-08-24T00:00:00",
+    "customFields": [{"label": "Event Title", "value": "First day of classes"}],
+    "categoryCalendar": "Academic|Fall",
+}
 
 
-class CalendarTest(unittest.TestCase):
-    @responses.activate
-    def test_calendar_endpoints(self):
-        event_data = [
-            {
-                "title": "Fall term begins",
-                "startDateTime": "2026-08-24T00:00:00",
-                "customFields": [{"label": "Event Title", "value": "First day of classes"}],
-                "categoryCalendar": "Academic|Fall",
-            }
-        ]
-        calendar_functions = {
-            cal.ACADEMIC_CALENDAR_URL: cal.get_academic_calendar,
-            cal.GRADES_CALENDAR_URL: cal.get_grades_calendar,
-            cal.ENROLLMENT_CALENDAR_URL: cal.get_enrollment_calendar,
-            cal.COURSE_CALENDAR_URL: cal.get_course_calendar,
-            cal.GRADUATION_CALENDAR_URL: cal.get_graduation_calendar,
-        }
+@responses.activate
+def test_calendar_endpoints():
+    client = CalendarClient()
+    endpoints = (
+        (ACADEMIC_CALENDAR_URL, client.get_academic_calendar),
+        (GRADES_CALENDAR_URL, client.get_grades_calendar),
+        (ENROLLMENT_CALENDAR_URL, client.get_enrollment_calendar),
+        (COURSE_CALENDAR_URL, client.get_course_calendar),
+        (GRADUATION_CALENDAR_URL, client.get_graduation_calendar),
+    )
+    expected = (
+        Event(
+            date="2026-08-24",
+            title="Fall term begins",
+            content="First day of classes",
+            categories=("Academic", "Fall"),
+        ),
+    )
 
-        for url, calendar_function in calendar_functions.items():
-            with self.subTest(url=url):
-                responses.add(responses.GET, url, json=event_data, status=200)
-                self.assertEqual(
-                    calendar_function(),
-                    [
-                        cal.Event(
-                            date="2026-08-24",
-                            title="Fall term begins",
-                            content="First day of classes",
-                            meta=["Academic", "Fall"],
-                        )
-                    ],
-                )
+    for url, method in endpoints:
+        responses.add(responses.GET, url, json=[EVENT_DATA])
+        assert method() == expected
+
+
+@responses.activate
+def test_calendar_requires_a_list():
+    responses.add(responses.GET, ACADEMIC_CALENDAR_URL, json={})
+    with pytest.raises(ValueError, match="list of events"):
+        CalendarClient().get_academic_calendar()
+
+
+def test_calendar_rejects_unexpected_custom_field():
+    event = EVENT_DATA | {"customFields": [{"label": "Other", "value": "value"}]}
+    with pytest.raises(ValueError, match="unexpected custom field"):
+        parse_event(event)
+
+
+def test_calendar_rejects_missing_data():
+    with pytest.raises(ValueError, match="missing required data"):
+        parse_event({})

--- a/tests/gym_test.py
+++ b/tests/gym_test.py
@@ -1,69 +1,69 @@
-import unittest
+import pytest
 import responses
-from pittapi import gym
-from tests.mocks.gym_mocks import mock_gym_html
+
+from pittapi.gym import GYM_URL, Gym, GymClient
+
+GYMS = [
+    {
+        "LocationId": 1,
+        "LocationName": "Campus Recreation",
+        "FacilityId": 10,
+        "FacilityName": "Baierl Rec Center",
+        "TotalCapacity": 200,
+        "LastCount": 0,
+        "PercetageCapacity": 0,
+        "LastUpdatedDateAndTime": "07/09/2024 09:05 AM",
+        "IsClosed": False,
+        "Ignored": "provider extension",
+    },
+    {
+        "LocationId": 2,
+        "LocationName": "Trees Hall",
+        "FacilityId": 20,
+        "FacilityName": "Trees Fitness Center",
+        "TotalCapacity": 100,
+        "LastCount": 0,
+        "PercetageCapacity": 0,
+        "LastUpdatedDateAndTime": "07/09/2024 09:06 AM",
+        "IsClosed": True,
+    },
+]
 
 
-class GymTest(unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        unittest.TestCase.__init__(self, *args, **kwargs)
+@responses.activate
+def test_fetch_all_gyms_preserves_zero_and_closed_state():
+    responses.add(responses.GET, GYM_URL, json=GYMS)
 
-    @responses.activate
-    def test_fetch_gym_info(self):
+    gyms = GymClient().get_all_gyms_info()
 
-        responses.add(responses.GET, gym.GYM_URL, body=mock_gym_html, status=200)
+    assert gyms[0] == Gym(
+        location_id=1,
+        location_name="Campus Recreation",
+        facility_id=10,
+        facility_name="Baierl Rec Center",
+        total_capacity=200,
+        current_count=0,
+        percent_full=0,
+        last_updated="07/09/2024 09:05 AM",
+        is_closed=False,
+    )
+    assert gyms[1].current_count == 0
+    assert gyms[1].is_closed
 
-        gym_info = gym.get_all_gyms_info()
-        expected_info = [
-            gym.Gym(name="Baierl Rec Center", last_updated="07/09/2024 09:05 AM", current_count=100, percent_full=50),
-            gym.Gym(
-                name="Bellefield Hall: Fitness Center & Weight Room",
-                last_updated="07/09/2024 09:05 AM",
-                current_count=50,
-                percent_full=0,
-            ),
-            gym.Gym(name="Bellefield Hall: Court & Dance Studio"),
-            gym.Gym(name="Trees Hall: Fitness Center", last_updated="07/09/2024 09:05 AM", current_count=70, percent_full=58),
-            gym.Gym(name="Trees Hall: Courts", last_updated="07/09/2024 09:05 AM", current_count=20, percent_full=33),
-            gym.Gym(
-                name="Trees Hall: Racquetball Courts & Multipurpose Room",
-                last_updated="07/09/2024 09:05 AM",
-                current_count=10,
-                percent_full=25,
-            ),
-            gym.Gym(name="William Pitt Union", last_updated="07/09/2024 09:05 AM", current_count=25, percent_full=25),
-            gym.Gym(name="Pitt Sports Dome", last_updated="07/09/2024 09:05 AM", current_count=15, percent_full=20),
-        ]
 
-        self.assertEqual(gym_info, expected_info)
+@responses.activate
+def test_get_gym_info_and_unknown_gym():
+    responses.add(responses.GET, GYM_URL, json=GYMS)
+    assert GymClient().get_gym_info("Campus Recreation").facility_id == 10
 
-    @responses.activate
-    def test_get_gym_info(self):
-        responses.add(responses.GET, gym.GYM_URL, body=mock_gym_html, status=200)
+    responses.add(responses.GET, GYM_URL, json=GYMS)
+    with pytest.raises(LookupError, match="gym not found"):
+        GymClient().get_gym_info("Missing Gym")
 
-        gym_info = gym.get_gym_info("Baierl Rec Center")
-        expected_info = gym.Gym(
-            name="Baierl Rec Center", last_updated="07/09/2024 09:05 AM", current_count=100, percent_full=50
-        )
-        self.assertEqual(gym_info, expected_info)
 
-    @responses.activate
-    def test_invalid_gym_name(self):
-        responses.add(responses.GET, gym.GYM_URL, body=mock_gym_html, status=200)
-
-        gym_info = gym.get_gym_info("Invalid Gym Name")
-        self.assertIsNone(gym_info)
-
-    @responses.activate
-    def test_valid_gym_name_not_all_info(self):
-        responses.add(responses.GET, gym.GYM_URL, body=mock_gym_html, status=200)
-
-        gym_info = gym.get_gym_info("Bellefield Hall: Court & Dance Studio")
-        self.assertIsNone(gym_info)
-
-    @responses.activate
-    def test_percentage_value_error(self):
-        responses.add(responses.GET, gym.GYM_URL, body=mock_gym_html, status=200)
-
-        gym_info = gym.get_gym_info("Bellefield Hall: Fitness Center & Weight Roomo")
-        self.assertIsNone(gym_info)
+@pytest.mark.parametrize("payload", [{}, [{}]])
+@responses.activate
+def test_malformed_gym_response(payload):
+    responses.add(responses.GET, GYM_URL, json=payload)
+    with pytest.raises(ValueError, match="gym response"):
+        GymClient().get_all_gyms_info()

--- a/tests/status_test.py
+++ b/tests/status_test.py
@@ -1,45 +1,40 @@
-"""
-The Pitt API, to access workable data of the University of Pittsburgh
-Copyright (C) 2015 Ritwik Gupta
-
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-"""
-
 import json
-import unittest
-import responses
-
 from pathlib import Path
 
-from pittapi import status
+import pytest
+import responses
 
-SAMPLE_PATH = Path() / "tests" / "samples"
+from pittapi.status import STATUS_URL, StatusClient, StatusSummary
+
+SAMPLE_PATH = Path("tests/samples/status.json")
 
 
-class StatusTest(unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        unittest.TestCase.__init__(self, *args, **kwargs)
-        with (SAMPLE_PATH / "status.json").open() as f:
-            self.status_data = json.load(f)
+@responses.activate
+def test_get_status_models_nested_data():
+    responses.add(responses.GET, STATUS_URL, json=json.loads(SAMPLE_PATH.read_text()))
 
-    @responses.activate
-    def test_get_status(self):
-        responses.add(
-            responses.GET,
-            "https://status.pitt.edu/index.json",
-            json=self.status_data,
-            status=200,
-        )
-        self.assertIsInstance(status.get_status(), dict)
+    result = StatusClient().get_status()
+
+    assert isinstance(result, StatusSummary)
+    assert result.components
+    assert result.incidents
+    assert result.incidents[0].incident_updates
+    assert result.incidents[0].incident_updates[0].affected_components
+
+
+@responses.activate
+def test_get_status_rejects_missing_data():
+    responses.add(responses.GET, STATUS_URL, json={})
+    with pytest.raises(ValueError, match="missing required data"):
+        StatusClient().get_status()
+
+
+@responses.activate
+def test_incident_update_allows_null_affected_components():
+    data = json.loads(SAMPLE_PATH.read_text())
+    data["incidents"][0]["incident_updates"][0]["affected_components"] = None
+    responses.add(responses.GET, STATUS_URL, json=data)
+
+    result = StatusClient().get_status()
+
+    assert result.incidents[0].incident_updates[0].affected_components == ()


### PR DESCRIPTION
Introduces the shared synchronous BaseClient and converts calendar, status, and gym services to readable client APIs with immutable dataclass models. Gym occupancy now uses GoBoard’s JSON feed, preserves zero counts, and represents closed state independently. Status parsing also supports provider updates whose affected-component list is null.